### PR TITLE
Generalizes tile size across tools, closes #18

### DIFF
--- a/robosat/datasets.py
+++ b/robosat/datasets.py
@@ -82,13 +82,12 @@ class BufferedSlippyMapDirectory(torch.utils.data.Dataset):
     '''Dataset for buffered slippy map tiles with overlap.
     '''
 
-    width, height = 512, 512
-
-    def __init__(self, root, transform=None, overlap=32):
+    def __init__(self, root, transform=None, size=512, overlap=32):
         '''
         Args:
           root: the slippy map directory root with a `z/x/y.png` sub-structure.
           transform: the transformation to run on the buffered tile.
+          size: the Slippy Map tile size in pixels
           overlap: the tile border to add on every side; in pixel.
 
         Note:
@@ -99,9 +98,11 @@ class BufferedSlippyMapDirectory(torch.utils.data.Dataset):
 
         super().__init__()
 
-        assert self.width == self.height, 'tiles are quadratic'
+        assert overlap >= 0
+        assert size >= 256
 
         self.transform = transform
+        self.size = size
         self.overlap = overlap
         self.tiles = list(tiles_from_slippy_map(root))
 
@@ -110,7 +111,7 @@ class BufferedSlippyMapDirectory(torch.utils.data.Dataset):
 
     def __getitem__(self, i):
         tile, path = self.tiles[i]
-        image = buffer_tile_image(tile, self.tiles, overlap=self.overlap, tile_size=self.width)
+        image = buffer_tile_image(tile, self.tiles, overlap=self.overlap, tile_size=self.size)
 
         if self.transform is not None:
             image = self.transform(image)

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -27,6 +27,7 @@ def add_parser(subparser):
     parser.add_argument('--batch_size', type=int, default=1, help='images per batch')
     parser.add_argument('--checkpoint', type=str, required=True, help='model checkpoint to load')
     parser.add_argument('--overlap', type=int, default=32, help='tile pixel overlap to predict on')
+    parser.add_argument('--tile_size', type=int, default=512, help='tile size for slippy map tiles')
     parser.add_argument('--workers', type=int, default=1, help='number of workers pre-processing images')
     parser.add_argument('tiles', type=str, help='directory to read slippy map image tiles from')
     parser.add_argument('probs', type=str, help='directory to save slippy map probability masks to')
@@ -70,7 +71,7 @@ def main(args):
         Normalize(mean=dataset['stats']['mean'], std=dataset['stats']['std'])
     ])
 
-    directory = BufferedSlippyMapDirectory(args.tiles, transform=transform, overlap=args.overlap)
+    directory = BufferedSlippyMapDirectory(args.tiles, transform=transform, size=args.tile_size, overlap=args.overlap)
     loader = DataLoader(directory, batch_size=args.batch_size)
 
     # don't track tensors with autograd during prediction

--- a/robosat/tools/serve.py
+++ b/robosat/tools/serve.py
@@ -39,11 +39,12 @@ session = None
 predictor = None
 tiles = None
 token = None
+size = None
 
 
 @app.route('/')
 def index():
-    return render_template('map.html', token=token)
+    return render_template('map.html', token=token, size=size)
 
 
 @app.route('/<int:z>/<int:x>/<int:y>.png')
@@ -84,6 +85,7 @@ def add_parser(subparser):
 
     parser.add_argument('--url', type=str, help='endpoint with {z}/{x}/{y} variables to fetch image tiles from')
     parser.add_argument('--checkpoint', type=str, required=True, help='model checkpoint to load')
+    parser.add_argument('--tile_size', type=int, default=512, help='tile size for slippy map tiles')
     parser.add_argument('--host', type=str, default='127.0.0.1', help='host to serve on')
     parser.add_argument('--port', type=int, default=5000, help='port to serve on')
 
@@ -98,6 +100,9 @@ def main(args):
 
     if cuda and not torch.cuda.is_available():
         sys.exit('Error: CUDA requested but not available')
+
+    global size
+    size = args.size
 
     global token
     token = os.getenv('MAPBOX_ACCESS_TOKEN')

--- a/robosat/tools/templates/map.html
+++ b/robosat/tools/templates/map.html
@@ -72,7 +72,7 @@ afterMap.on('load', function() {
     'source': {
       'type': 'raster',
       'tiles': [ 'http://127.0.0.1:5000/{z}/{x}/{y}.png' ],
-      'tileSize': 512
+      'tileSize': {{ size }}
     }
   });
 


### PR DESCRIPTION
For #18. Let's the user pass in the slippy map tile size in tools.

This allows users to work e.g. with 256x256 tiles or 512x512 tiles.