### PR TITLE
Saves only unique tile ids in `rs cover`, closes #24

### DIFF
--- a/robosat/tools/cover.py
+++ b/robosat/tools/cover.py
@@ -22,8 +22,12 @@ def main(args):
         features = json.load(f)
 
     tiles = []
+
     for feature in tqdm(features['features'], ascii=True, unit='feature'):
         tiles.extend(burntiles.burn([feature], args.zoom))
+
+    # tiles can overlap for multiple features; unique tile ids
+    tiles = list(set(tiles))
 
     with open(args.out, 'w') as fp:
         writer = csv.writer(fp)


### PR DESCRIPTION
See #24. Looks like the list of tile ids we generated was not unique before which causes some confusions.

Now `rs cover` generates a _unique_ list of tile ids.