### PR TITLE
Adds ONNX model exporter; closes #38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .env
-pth*
+.python-version
 __pycache__
 test
 data
+
+*.pth
+*.pb

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     - [download](#rs-download)
     - [rasterize](#rs-rasterize)
     - [train](#rs-train)
+    - [export](#rs-export)
     - [predict](#rs-predict)
     - [mask](#rs-mask)
     - [features](#rs-features)
@@ -175,6 +176,15 @@ Before you can start training you need the following.
 - You need to add the path to the dataset's directory and the calculated class weights and statistics to the dataset config.
 
 Note: If you run `rs train` in an environment without X11 you need to set `export MPLBACKEND="agg"` for charts, see [the matplotlib docs](https://matplotlib.org/faq/howto_faq.html#matplotlib-in-a-web-application-server).
+
+
+### rs export
+
+Exports a trained model in [ONNX](https://onnx.ai/) format for prediction across different backends (like Caffe2, TensorFlow).
+
+The result of `rs export` is an ONNX GraphProto `.pb` file which can be used with the ONNX ecosystem.
+
+Note: the `rs predict` tool works with `.pth` checkpoints. In contrast to these `.pth` checkpoints the ONNX models neither depent on PyTorch or the Python code for the model class and can be used e.g. in resource constrained environments like AWS Lambda.
 
 
 ### rs predict

--- a/robosat/tools/__main__.py
+++ b/robosat/tools/__main__.py
@@ -8,6 +8,7 @@ from robosat.tools import (
     dedupe,
     download,
     extract,
+    export,
     features,
     masks,
     merge,
@@ -32,6 +33,7 @@ def add_parsers():
     rasterize.add_parser(subparser)
 
     train.add_parser(subparser)
+    export.add_parser(subparser)
     predict.add_parser(subparser)
     masks.add_parser(subparser)
     features.add_parser(subparser)

--- a/robosat/tools/export.py
+++ b/robosat/tools/export.py
@@ -1,0 +1,37 @@
+import argparse
+
+import torch
+import torch.onnx
+import torch.autograd
+
+from robosat.config import load_config
+from robosat.unet import UNet
+
+
+def add_parser(subparser):
+    parser = subparser.add_parser(
+        "export", help="exports model in ONNX format", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("--dataset", type=str, required=True, help="path to dataset configuration file")
+    parser.add_argument("--image_size", type=int, default=512, help="image size to use for model")
+    parser.add_argument("--checkpoint", type=str, required=True, help="model checkpoint to load")
+    parser.add_argument("model", type=str, help="path to save ONNX GraphProto .pb model to")
+
+    parser.set_defaults(func=main)
+
+
+def main(args):
+    dataset = load_config(args.dataset)
+
+    num_classes = len(dataset["common"]["classes"])
+    net = UNet(num_classes)
+
+    chkpt = torch.load(args.checkpoint, map_location="cpu")
+    net.load_state_dict(chkpt)
+    net = torch.nn.DataParallel(net)
+
+    # Todo: make input channels configurable, not hard-coded to three channels for RGB
+    batch = torch.autograd.Variable(torch.randn(1, 3, args.image_size, args.image_size))
+
+    torch.onnx.export(net, batch, args.model)

--- a/robosat/unet.py
+++ b/robosat/unet.py
@@ -89,6 +89,8 @@ class UNet(nn.Module):
 
         super().__init__()
 
+        # Todo: make input channels configurable, not hard-coded to three channels for RGB
+
         self.resnet = resnet50(pretrained=pretrained)
 
         self.enc0 = nn.Sequential(self.resnet.conv1, self.resnet.bn1, self.resnet.relu, self.resnet.maxpool)


### PR DESCRIPTION
For #38.

This changeset adds an ONNX exporter serializing the model and its weights into a GraphProto `.pb` file. This file no longer depends on PyTorch or the Python model class and can be used with tools from the ONNX ecosystem.

For example

```
model = onnx.load('buildings-z20-tanzania.pb')
onnx.checker.check_model(model)
print(onnx.helper.printable_graph(model.graph))
```

This will allow us to store and provide models which then can be used e.g. in Caffe2 or TensorFlow.