### PR TITLE
Orient exterior ring of the polygon in counter-clockwise direction

### DIFF
--- a/robosat/tools/merge.py
+++ b/robosat/tools/merge.py
@@ -65,6 +65,9 @@ def main(args):
         merged = unbuffered(union(embiggened))
 
         if merged.is_valid:
+            # Orient exterior ring of the polygon in counter-clockwise direction.
+            merged = shapely.geometry.polygon.orient(merged, sign=1.0)
+
             # equal-area projection; round to full m^2, we're not that precise anyway
             area = int(round(project(merged, "epsg:4326", "esri:54009").area))
 


### PR DESCRIPTION
Closes: https://github.com/mapbox/robosat/issues/1

From https://shapely.readthedocs.io/en/stable/manual.html#shapely.geometry.polygon.orient

> **shapely.geometry.polygon.orient(polygon, sign=1.0)**
>
> Returns a properly oriented copy of the given polygon. The signed area of the result will have the given sign. A sign of 1.0 means that the coordinates of the product’s exterior ring will be oriented counter-clockwise.