### PR TITLE
Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM pytorch:latest
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	build-essential \
+	libboost-python-dev \
+	libexpat1-dev \
+	zlib1g-dev \
+	libbz2-dev \
+	libgtk2.0-dev \
+	libspatialindex-dev
+
+ADD . /robo-src
+WORKDIR /robo-src
+RUN pip install -r deps/requirements-lock.txt
+
+RUN python3 -m pip uninstall -y osmium
+RUN rm -rf ~/.cache/pip/wheels/
+RUN rm /usr/lib/x86_64-linux-gnu/libboost_python.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python-py35.so /usr/lib/x86_64-linux-gnu/libboost_python.so
+RUN yes | python3 -m pip install osmium
+
+ENTRYPOINT ["./rs"]
+CMD ["--help"]


### PR DESCRIPTION
Attempts to address mapbox/robosat/issues/29.

To build the container, first build a pytorch container following their instructions in the README. Specifically:
```
git clone https://github.com/pytorch/pytorch && cd pytorch
docker build -t pytorch -f docker/pytorch/Dockerfile .
```
This is necessary because there isnt currently an officially maintained container on DockerHub.

Then, build the Robosat container:
```
cd .. && git clone https://github.com/mapbox/robosat && cd robosat
docker build -t robosat -f docker/Dockerfile .
```

Thus far, I have tested `./rs extract` and `./rs cover` without issue.