### PR TITLE
Removes vertical flip: horizontal plus n*90 degree is equivalent

### DIFF
--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -17,7 +17,6 @@ from tqdm import tqdm
 from robosat.transforms import (
     JointCompose,
     JointTransform,
-    JointRandomVerticalFlip,
     JointRandomHorizontalFlip,
     JointRandomRotation,
     ConvertImageMode,
@@ -185,7 +184,6 @@ def get_dataset_loaders(model, dataset):
             JointTransform(ConvertImageMode("RGB"), ConvertImageMode("P")),
             JointTransform(Resize(target_size, Image.BILINEAR), Resize(target_size, Image.NEAREST)),
             JointTransform(CenterCrop(target_size), CenterCrop(target_size)),
-            JointRandomVerticalFlip(0.5),
             JointRandomHorizontalFlip(0.5),
             JointRandomRotation(0.5, 90),
             JointRandomRotation(0.5, 180),

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -186,8 +186,8 @@ def get_dataset_loaders(model, dataset):
             JointTransform(CenterCrop(target_size), CenterCrop(target_size)),
             JointRandomHorizontalFlip(0.5),
             JointRandomRotation(0.5, 90),
-            JointRandomRotation(0.5, 180),
-            JointRandomRotation(0.5, 270),
+            JointRandomRotation(0.5, 90),
+            JointRandomRotation(0.5, 90),
             JointTransform(ImageToTensor(), MaskToTensor()),
             JointTransform(Normalize(mean=mean, std=std), None),
         ]


### PR DESCRIPTION
Horizontal flipping plus the four rotations by 0, 90, 180, 270 degrees are enough to result in all transformations we would get out of adding vertical flipping to the mix.

See https://en.wikipedia.org/wiki/Dihedral_group