### PR TITLE
Shuffles the training dataset which is based on slippy map dir order

### DIFF
--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -201,7 +201,7 @@ def get_dataset_loaders(model, dataset):
         [os.path.join(path, "validation", "images")], os.path.join(path, "validation", "labels"), transform
     )
 
-    train_loader = DataLoader(train_dataset, batch_size=batch_size, drop_last=True)
-    val_loader = DataLoader(val_dataset, batch_size=batch_size, drop_last=True)
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+    val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, drop_last=True)
 
     return train_loader, val_loader


### PR DESCRIPTION
Our slippy map dataset reads in tiles and sorts them by their [mercantile.Tile](http://mercantile.readthedocs.io/en/latest/api/mercantile.html#mercantile.Tile) (x, y, z) attributes.

https://github.com/mapbox/robosat/blob/5f35f2b16917a12ffce7fb8671ba27bbbd770a4c/robosat/datasets.py#L16-L39

This results in us training the model on neighboring strips of tiles when we don't shuffle the dataset. And currently we don't shuffle the dataset:

https://github.com/mapbox/robosat/blob/master/robosat/tools/train.py#L204-L205

This changeset shuffles the training dataset to get rid of any spatial dependence. The validation dataset can be in order since we only calculate the metrics at the end of an epoch and shuffling doesn't change anything here.

cc @maning 