### PR TITLE
Wraps model in DataParallel during training on CPUs, closes #41

### DIFF
--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -57,11 +57,12 @@ def main(args):
     os.makedirs(model["common"]["checkpoint"], exist_ok=True)
 
     num_classes = len(dataset["common"]["classes"])
-    net = UNet(num_classes).to(device)
+    net = UNet(num_classes)
+    net = DataParallel(net)
+    net = net.to(device)
 
     if model["common"]["cuda"]:
         torch.backends.cudnn.benchmark = True
-        net = DataParallel(net)
 
     optimizer = Adam(net.parameters(), lr=model["opt"]["lr"], weight_decay=model["opt"]["decay"])
 


### PR DESCRIPTION
For #41.

We were only wrapping the model in a DataParallel module when on the CUDA path during training. In the unlikely event that folks want to train on CPUs we should at least make sure we can load the trained model again.