### PR TITLE
Tool to write slippy map directory to a csv file

### DIFF
--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -120,6 +120,24 @@ def tiles_from_csv(path):
             yield mercantile.Tile(*map(int, row))
 
 
+def tiles_to_csv(tiles, path):
+    """Read tiles from a line-delimited csv file.
+
+    Args:
+      tiles: the mercantile tiles to write.
+      file: the path to write the csv file to.
+    """
+
+    rows = []
+
+    for tile in tiles:
+        rows.append(map(str, [tile.x, tile.y, tile.z]))
+
+    with open(path, "w") as fp:
+        writer = csv.writer(fp)
+        writer.writerows(rows)
+
+
 def stitch_image(into, into_box, image, image_box):
     """Stitches two images together in-place.
 

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -121,11 +121,11 @@ def tiles_from_csv(path):
 
 
 def tiles_to_csv(tiles, path):
-    """Read tiles from a line-delimited csv file.
+    """Write tiles to a line-delimited csv file.
 
     Args:
       tiles: the mercantile tiles to write.
-      file: the path to write the csv file to.
+      path: the path to write the csv file to.
     """
 
     rows = []

--- a/robosat/tools/__main__.py
+++ b/robosat/tools/__main__.py
@@ -5,6 +5,7 @@ import argparse
 from robosat.tools import (
     compare,
     cover,
+    csv,
     dedupe,
     download,
     extract,
@@ -44,6 +45,7 @@ def add_parsers():
 
     weights.add_parser(subparser)
 
+    csv.add_parser(subparser)
     compare.add_parser(subparser)
     subset.add_parser(subparser)
 

--- a/robosat/tools/csv.py
+++ b/robosat/tools/csv.py
@@ -1,0 +1,29 @@
+import argparse
+import random
+
+from robosat.tiles import tiles_from_slippy_map, tiles_to_csv
+
+
+def main(args):
+    tiles = []
+    for tile, path in tiles_from_slippy_map(args.dir):
+        tiles.append(tile)
+
+    if args.shuffle:
+        random.shuffle(tiles)
+
+    if args.count:
+        tiles = tiles[: args.count]
+
+    tiles_to_csv(tiles, args.out)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process some integers.")
+
+    parser.add_argument("dir", type=str, help="slippy map directory to read images from")
+    parser.add_argument("out", type=str, help="path to write csv of all images in the directory")
+    parser.add_argument("--shuffle", type=bool, default=False, help="whether to shuffle the images")
+    parser.add_argument("--count", type=int, default=None, help="Maximum number of images in the csv")
+
+    main(parser.parse_args())

--- a/robosat/tools/csv.py
+++ b/robosat/tools/csv.py
@@ -18,12 +18,16 @@ def main(args):
     tiles_to_csv(tiles, args.out)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Process some integers.")
+def add_parser(subparser):
+    parser = subparser.add_parser(
+        "csv",
+        help="writes files in a slippy map directory to a file",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     parser.add_argument("dir", type=str, help="slippy map directory to read images from")
-    parser.add_argument("out", type=str, help="path to write csv of all images in the directory")
+    parser.add_argument("out", type=str, help="path to write csv of all images in directory")
     parser.add_argument("--shuffle", type=bool, default=False, help="whether to shuffle the images")
-    parser.add_argument("--count", type=int, default=None, help="Maximum number of images in the csv")
+    parser.add_argument("--count", type=int, default=None, help="number of images to write to csv")
 
-    main(parser.parse_args())
+    parser.set_defaults(func=main)

--- a/robosat/tools/csv.py
+++ b/robosat/tools/csv.py
@@ -15,7 +15,7 @@ def main(args):
     if args.count:
         tiles = tiles[: args.count]
 
-    tiles_to_csv(tiles, args.out)
+    tiles_to_csv(sorted(tiles), args.out)
 
 
 def add_parser(subparser):


### PR DESCRIPTION
We have a slippy map directory with X items (1000 in this example) and we want a subset of Y items (5 in this example). There are a couple of additional options that are common to data workflows:
- Shuffle images at random, `--shuffle`
- Get required number of images, `--count`

## Workflow

```bash
$ find "images/" -type f | wc -l
1000


# Get a csv file for the slippy map directory.
$ ./rs csv "images/" "images.csv" --shuffle true --count 5


# Five items since we asked so with --count 5
$ cat images.csv
41483,95309,18
41484,95309,18
41505,94409,18
41487,94309,18
41504,94409,18
```

The logical next step here is to use `rs subset` tool to get a subset of images per csv file.

```bash
# Use csv to prepare a subset slippy map directory.
$ ./rs subset "images/" "images.csv" "subset/"


# Slippy map directory now has only the files in the csv.
$ find "subset/" -type f
subset/18/41505/94409.webp
subset/18/41484/95309.webp
subset/18/41504/94409.webp
subset/18/41487/94309.webp
subset/18/41483/95309.webp
```