### PR TITLE
Compare tool works with just images and labels

### DIFF
--- a/robosat/tools/compare.py
+++ b/robosat/tools/compare.py
@@ -17,7 +17,7 @@ def add_parser(subparser):
     parser.add_argument("out", type=str, help="directory to save visualizations to")
     parser.add_argument("images", type=str, help="directory to read slippy map images from")
     parser.add_argument("labels", type=str, help="directory to read slippy map labels from")
-    parser.add_argument("masks", type=str, nargs="+", help="slippy map directories to read masks from")
+    parser.add_argument("masks", type=str, nargs="*", help="slippy map directories to read masks from")
     parser.add_argument("--minimum", type=float, default=0.0, help="minimum percentage of mask not background")
     parser.add_argument("--maximum", type=float, default=1.0, help="maximum percentage of mask not background")
 
@@ -48,7 +48,7 @@ def main(args):
             if percentage >= args.minimum and percentage <= args.maximum:
                 keep = True
 
-        if not keep:
+        if args.masks and not keep:
             continue
 
         width, height = image.size


### PR DESCRIPTION
While cleaning up datasets, we want to look at just the images and their labels. The current `rs compare` requires at-least one masks directory and this PR makes the masks directory optional, one ore more to be precise! Now, we could use this tool to generate images like below:

![95309](https://user-images.githubusercontent.com/2899501/42749960-2b0472ba-8903-11e8-8210-4d2efe5f9793.png)
