### PR TITLE
add Dockerfile and Docker Hub images for robosat

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,7 +1,5 @@
 FROM ubuntu:16.04    
     
-# MAINTAINER sshuair<sshuair@gmail.com>    
-    
 ARG TORCH=0.4.0    
 ARG CUDA=91    
 ARG PYTHON=35    

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -28,7 +28,6 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\
 RUN pip3 --no-cache-dir install setuptools && \    
     pip3 --no-cache-dir install http://download.pytorch.org/whl/cpu/torch-${TORCH}-cp${PYTHON}-cp${PYTHON}m-linux_x86_64.whl    
         
-    
 # get robosat    
 RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \    
     cd /root/robosat && \    

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,0 +1,63 @@
+FROM ubuntu:16.04
+
+# MAINTAINER sshuair<sshuair@gmail.com>
+
+# install dependencies
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\ 
+        build-essential \
+        software-properties-common \
+        curl \
+        cmake \
+        libfreetype6-dev \
+        libpng12-dev \
+        libzmq3-dev \
+        libspatialindex-dev \
+        pkg-config \
+        rsync \
+        zip \
+        unzip \
+        git \
+        wget \
+        vim \
+        ca-certificates \
+        python3 \
+        python3-dev \
+        python3-pip \
+        ipython3 \
+        libboost-python-dev \
+        libexpat1-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install python package
+RUN pip3 --no-cache-dir install setuptools && \
+    pip3 --no-cache-dir install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl && \
+    pip3 --no-cache-dir install \
+        ipykernel \
+        jupyter \
+        torchvision \
+        && \
+    python3 -m ipykernel.kernelspec
+
+# get robosat
+RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \
+    cd /root/robosat && \
+    pip3 --no-cache-dir install -r deps/requirements-lock.txt 
+
+# Set up our notebook config.
+COPY jupyter_notebook_config.py /root/.jupyter/
+
+# Jupyter has issues with being run directly: https://github.com/ipython/ipython/issues/7062
+COPY run_jupyter.sh /
+
+# jupyter noteboook(8888)
+EXPOSE 8888
+
+WORKDIR "/root/robosat"
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,63 +1,40 @@
-FROM ubuntu:16.04
-
-# MAINTAINER sshuair<sshuair@gmail.com>
-
-# install dependencies
-RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\ 
+FROM ubuntu:16.04    
+    
+# MAINTAINER sshuair<sshuair@gmail.com>    
+    
+ARG TORCH=0.4.0    
+ARG CUDA=91    
+ARG PYTHON=35    
+    
+# install dependencies    
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\     
         build-essential \
-        software-properties-common \
-        curl \
-        cmake \
-        libfreetype6-dev \
-        libpng12-dev \
-        libzmq3-dev \
-        libspatialindex-dev \
-        pkg-config \
-        rsync \
-        zip \
-        unzip \
-        git \
-        wget \
-        vim \
-        ca-certificates \
         python3 \
         python3-dev \
+        python3-tk \
         python3-pip \
-        ipython3 \
+        build-essential \
         libboost-python-dev \
         libexpat1-dev \
         zlib1g-dev \
         libbz2-dev \
+        libspatialindex-dev \
         libsm6 \
-        libxext6 \
-        libxrender1 \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# install python package
-RUN pip3 --no-cache-dir install setuptools && \
-    pip3 --no-cache-dir install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl && \
-    pip3 --no-cache-dir install \
-        ipykernel \
-        jupyter \
-        torchvision \
-        && \
-    python3 -m ipykernel.kernelspec
-
-# get robosat
-RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \
-    cd /root/robosat && \
-    pip3 --no-cache-dir install -r deps/requirements-lock.txt 
-
-# Set up our notebook config.
-COPY jupyter_notebook_config.py /root/.jupyter/
-
-# Jupyter has issues with being run directly: https://github.com/ipython/ipython/issues/7062
-COPY run_jupyter.sh /
-
-# jupyter noteboook(8888)
-EXPOSE 8888
-
-WORKDIR "/root/robosat"
+        libglib2.0-0 \
+        git \
+        && \    
+    apt-get clean && \    
+    rm -rf /var/lib/apt/lists/*    
+    
+# install python package    
+RUN pip3 --no-cache-dir install setuptools && \    
+    pip3 --no-cache-dir install http://download.pytorch.org/whl/cpu/torch-${TORCH}-cp${PYTHON}-cp${PYTHON}m-linux_x86_64.whl    
+        
+    
+# get robosat    
+RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \    
+    cd /root/robosat && \    
+    pip3 --no-cache-dir install -r deps/requirements-lock.txt     
+    
+WORKDIR "/root/robosat"    
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/9.1-cudnn7-devel-ubuntu16.04
+FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
 
 # MAINTAINER sshuair<sshuair@gmail.com>    
     

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,7 +1,5 @@
 FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
 
-# MAINTAINER sshuair<sshuair@gmail.com>    
-    
 ARG TORCH=0.4.0    
 ARG CUDA=91    
 ARG PYTHON=35    

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -31,7 +31,7 @@ RUN pip3 --no-cache-dir install setuptools && \
 # get robosat    
 RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \    
     cd /root/robosat && \    
-    pip3 --no-cache-dir -r deps/requirements-lock.txt     
+    pip3 --no-cache-dir install -r deps/requirements-lock.txt     
     
 WORKDIR "/root/robosat"    
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,70 +1,40 @@
-FROM nvidia/cuda:9.0-base-ubuntu16.04
+FROM nvidia/9.1-cudnn7-devel-ubuntu16.04
 
-# MAINTAINER sshuair<sshuair@gmail.com>
-
-# install dependencies
-RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\ 
+# MAINTAINER sshuair<sshuair@gmail.com>    
+    
+ARG TORCH=0.4.0    
+ARG CUDA=91    
+ARG PYTHON=35    
+    
+# install dependencies    
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\     
         build-essential \
-        software-properties-common \
-        curl \
-        cmake \
-        cuda-command-line-tools-9-0 \
-        cuda-cublas-9-0 \
-        cuda-cufft-9-0 \
-        cuda-curand-9-0 \
-        cuda-cusolver-9-0 \
-        cuda-cusparse-9-0 \
-        libcudnn7=7.0.5.15-1+cuda9.0 \
-        libfreetype6-dev \
-        libpng12-dev \
-        libzmq3-dev \
-        libspatialindex-dev \
-        pkg-config \
-        rsync \
-        zip \
-        unzip \
-        git \
-        wget \
-        vim \
-        ca-certificates \
         python3 \
         python3-dev \
+        python3-tk \
         python3-pip \
-        ipython3 \
+        build-essential \
         libboost-python-dev \
         libexpat1-dev \
         zlib1g-dev \
         libbz2-dev \
+        libspatialindex-dev \
         libsm6 \
-        libxext6 \
-        libxrender1 \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+        libglib2.0-0 \
+        git \
+        && \    
+    apt-get clean && \    
+    rm -rf /var/lib/apt/lists/*    
 
 # install python package
 RUN pip3 --no-cache-dir install setuptools && \
-    pip3 --no-cache-dir install http://download.pytorch.org/whl/cu90/torch-0.4.0-cp35-cp35m-linux_x86_64.whl  && \
-    pip3 --no-cache-dir install \
-        ipykernel \
-        jupyter \
-        torchvision \
-        && \
-    python3 -m ipykernel.kernelspec
+    pip3 --no-cache-dir install http://download.pytorch.org/whl/cu${CUDA}/torch-${TORCH}-cp${PYTHON}-cp{PYTHON}m-linux_x86_64.whl
 
-# get robosat
-RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \
-    cd /root/robosat && \
-    pip3 --no-cache-dir install -r deps/requirements-lock.txt 
 
-# Set up our notebook config.
-COPY jupyter_notebook_config.py /root/.jupyter/
-
-# Jupyter has issues with being run directly: https://github.com/ipython/ipython/issues/7062
-COPY run_jupyter.sh /
-
-# jupyter noteboook(8888)
-EXPOSE 8888
-
-WORKDIR "/root/robosat"
+# get robosat    
+RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \    
+    cd /root/robosat && \    
+    pip3 --no-cache-dir -r deps/requirements-lock.txt     
+    
+WORKDIR "/root/robosat"    
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -26,8 +26,7 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\
 
 # install python package
 RUN pip3 --no-cache-dir install setuptools && \
-    pip3 --no-cache-dir install http://download.pytorch.org/whl/cu${CUDA}/torch-${TORCH}-cp${PYTHON}-cp{PYTHON}m-linux_x86_64.whl
-
+    pip3 --no-cache-dir install http://download.pytorch.org/whl/cu${CUDA}/torch-${TORCH}-cp${PYTHON}-cp${PYTHON}m-linux_x86_64.whl
 
 # get robosat    
 RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \    

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,0 +1,70 @@
+FROM nvidia/cuda:9.0-base-ubuntu16.04
+
+# MAINTAINER sshuair<sshuair@gmail.com>
+
+# install dependencies
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends\ 
+        build-essential \
+        software-properties-common \
+        curl \
+        cmake \
+        cuda-command-line-tools-9-0 \
+        cuda-cublas-9-0 \
+        cuda-cufft-9-0 \
+        cuda-curand-9-0 \
+        cuda-cusolver-9-0 \
+        cuda-cusparse-9-0 \
+        libcudnn7=7.0.5.15-1+cuda9.0 \
+        libfreetype6-dev \
+        libpng12-dev \
+        libzmq3-dev \
+        libspatialindex-dev \
+        pkg-config \
+        rsync \
+        zip \
+        unzip \
+        git \
+        wget \
+        vim \
+        ca-certificates \
+        python3 \
+        python3-dev \
+        python3-pip \
+        ipython3 \
+        libboost-python-dev \
+        libexpat1-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install python package
+RUN pip3 --no-cache-dir install setuptools && \
+    pip3 --no-cache-dir install http://download.pytorch.org/whl/cu90/torch-0.4.0-cp35-cp35m-linux_x86_64.whl  && \
+    pip3 --no-cache-dir install \
+        ipykernel \
+        jupyter \
+        torchvision \
+        && \
+    python3 -m ipykernel.kernelspec
+
+# get robosat
+RUN git clone https://github.com/mapbox/robosat.git /root/robosat && \
+    cd /root/robosat && \
+    pip3 --no-cache-dir install -r deps/requirements-lock.txt 
+
+# Set up our notebook config.
+COPY jupyter_notebook_config.py /root/.jupyter/
+
+# Jupyter has issues with being run directly: https://github.com/ipython/ipython/issues/7062
+COPY run_jupyter.sh /
+
+# jupyter noteboook(8888)
+EXPOSE 8888
+
+WORKDIR "/root/robosat"
+CMD ["/bin/bash"]


### PR DESCRIPTION
refer to issue #29 and pr #67 , I add docker file for both cpu and gpu dockerfile and the images.

you can pull the image from dockerhub: https://hub.docker.com/r/sshuair/robosat/tags/

`docker pull sshuair/robosat:cpu` or `docker pull sshuair/robosat:gpu`

and now the follow item has been finished:
- [x]  Write Dockerfile for nvidia-docker plugin
- [x]   Install NVIDIA drivers, CUDA, cuDNN
- [x]   Install RoboSat deps. and make binaries docker run-able
- [x]   Test (currently test `./rs cover` and `./rs extract`)
- [x]   Set up automated Docker Hub builds

How to use:
1. pull the image from docker hub: `docker pull sshuair/robosat:cpu` or `docker pull sshuair/robosat:gpu`.
2. start the container: `sudo docker-nvidia run -ti --rm sshuair/sshuair/robosat:gpu` or `sudo docker run -ti --rm sshuair/sshuair/robosat:cpu`.
3. then you will enter the `robosat` directory.
4. run command `./rs --help`, it should be work.

![2018-07-18 6 35 05](https://user-images.githubusercontent.com/5787131/42876476-5e04b19a-8ab9-11e8-9606-8f1414044840.png)
