### PR TITLE
Assert image resolution has to be divisible by 32 for resnet

### DIFF
--- a/robosat/unet.py
+++ b/robosat/unet.py
@@ -116,6 +116,8 @@ class UNet(nn.Module):
         Returns:
           The networks output tensor.
         """
+        size = x.size()
+        assert size[-1] % 32 == 0 and size[-2] % 32 == 0, "image resolution has to be divisible by 32 for resnet"
 
         enc0 = self.resnet.conv1(x)
         enc0 = self.resnet.bn1(enc0)


### PR DESCRIPTION
With this fix, getting predictions with overlap % 32 != 0 will result in the following assertion.

```bash
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/app/robosat/robosat/tools/__main__.py", line 57, in <module>
    args.func(args)
  File "/app/robosat/robosat/tools/predict.py", line 82, in main
    outputs = net(images)
  File "/usr/local/lib/python3.5/dist-packages/torch/nn/modules/module.py", line 491, in __call__
    result = self.forward(*input, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/torch/nn/parallel/data_parallel.py", line 112, in forward
    return self.module(*inputs[0], **kwargs[0])
  File "/usr/local/lib/python3.5/dist-packages/torch/nn/modules/module.py", line 491, in __call__
    result = self.forward(*input, **kwargs)
  File "/app/robosat/robosat/unet.py", line 120, in forward
    assert size[-1] % 32 == 0 and size[-2] % 32 == 0, "image resolution has to be divisible by 32 for resnet"
AssertionError: image resolution has to be divisible by 32 for resnet
```


@daniel-j-h how do you want to get a similar fix to https://github.com/mapbox/robosat/pull/75