### PR TITLE
Allows for batch-rasterization in `rs rasterize`, closes #25

### DIFF
--- a/tests/tools/test_rasterize.py
+++ b/tests/tools/test_rasterize.py
@@ -4,6 +4,8 @@ import unittest
 import numpy as np
 import mercantile
 
+from PIL import Image
+
 from robosat.tools.rasterize import burn, feature_to_mercator
 
 
@@ -23,6 +25,7 @@ class TestBurn(unittest.TestCase):
         tile = mercantile.Tile(70762, 104119, 18)
 
         rasterized = burn(tile, parking_fc["features"], 512)
+        rasterized = Image.fromarray(rasterized, mode="P")
 
         # rasterized.save('rasterized.png')
 
@@ -38,6 +41,7 @@ class TestBurn(unittest.TestCase):
         tile = mercantile.Tile(69623, 104946, 18)
 
         rasterized = burn(tile, parking_fc["features"], 512)
+        rasterized = Image.fromarray(rasterized, mode="P")
 
         self.assertEqual(rasterized.size, (512, 512))
 


### PR DESCRIPTION
For https://github.com/mapbox/robosat/issues/25. This changeset allows for batch-rasterization.

We can now run `rs rasterize` multiple times with multiple smaller (batched) GeoJSON files. And in the case of overlapping features (multiple GeoJSON files with features in the same tile) we now automatically merge the rasterized masks on the fly.

This will make pre-processing a bit easier on memory for folks.

@rory