### PR TITLE
MultiBands, and tools improvements (mostly)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,5 @@
 Daniel J. Hofmann <Hofmann@Mapbox.com> https://github.com/daniel-j-h
 
 Bhargav Kowshik <Bhargav@Mapbox.com> https://github.com/bkowshik
+
+Olivier Courtin <o@datapink.com> https://github.com/ocourtin

--- a/config/dataset-parking.toml
+++ b/config/dataset-parking.toml
@@ -15,14 +15,17 @@
   # Note: available colors can be found in `robosat/colors.py`
   colors  = ['denim', 'orange']
 
-  # Input Tensor is composed by several images bands
-  # Channels configuration let your indicate wich dataset sub-directory and band are concerned
-  # Order is meaningful, syntax is: directory_name:band_number (1-n notation)
-  channels = ['images:1', 'images:2', 'images:3']
-
 
 # Dataset specific class weights computes on the training data.
 # Needed by 'mIoU' and 'CrossEntropy' losses to deal with unbalanced classes.
 # Note: use `./rs weights -h` to compute these for new datasets.
 [weights]
   values = [1.6248, 5.762827]
+
+
+# Channels configuration let your indicate wich dataset sub-directory and bands to take as input
+# You could so, add several channels blocks to compose your input Tensor. Orders are meaningful.
+[[channels]]
+type = "file"
+sub = "images"
+bands = [1,2,3]

--- a/config/dataset-parking.toml
+++ b/config/dataset-parking.toml
@@ -15,6 +15,11 @@
   # Note: available colors can be found in `robosat/colors.py`
   colors  = ['denim', 'orange']
 
+  # Input Tensor is composed by several images bands
+  # Channels configuration let your indicate wich dataset sub-directory and band are concerned
+  # Order is meaningful, syntax is: directory_name:band_number (1-n notation)
+  channels = ['images:1', 'images:2', 'images:3']
+
 
 # Dataset specific class weights computes on the training data.
 # Needed by 'mIoU' and 'CrossEntropy' losses to deal with unbalanced classes.

--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -32,3 +32,6 @@
 
   # Loss function name (e.g 'Lovasz', 'mIoU' or 'CrossEntropy')
   loss = 'Lovasz'
+
+  # Upscale input value factor to enhance resolution (classical values: 1, 2 or 4)
+  upscale_factor = 1

--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -33,5 +33,5 @@
   # Loss function name (e.g 'Lovasz', 'mIoU' or 'CrossEntropy')
   loss = 'Lovasz'
 
-  # Data augmentation, Flip or Rotate probabilty
+  # Data augmentation, Flip or Rotate probability
   data_augmentation = 0.75

--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -5,9 +5,6 @@
 # Model specific common attributes.
 [common]
 
-  # Use CUDA for GPU acceleration.
-  cuda       = true
-
   # Batch size for training.
   batch_size = 2
 

--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -33,5 +33,8 @@
   # Loss function name (e.g 'Lovasz', 'mIoU' or 'CrossEntropy')
   loss = 'Lovasz'
 
-  # Upscale factor to input image resolution (classical values: 1, 2 or 4) 
-  image_upscale = 1
+  # Resize factor to input image resolution
+  image_resize_factor = 1
+
+  # Data augmentation, Flip or Rotate probabilty
+  flip_or_rotate_prob = 0.25

--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -33,5 +33,5 @@
   # Loss function name (e.g 'Lovasz', 'mIoU' or 'CrossEntropy')
   loss = 'Lovasz'
 
-  # Upscale input value factor to enhance resolution (classical values: 1, 2 or 4)
-  upscale_factor = 1
+  # Upscale factor to input image resolution (classical values: 1, 2 or 4) 
+  image_upscale = 1

--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -33,8 +33,5 @@
   # Loss function name (e.g 'Lovasz', 'mIoU' or 'CrossEntropy')
   loss = 'Lovasz'
 
-  # Resize factor to input image resolution
-  image_resize_factor = 1
-
   # Data augmentation, Flip or Rotate probabilty
-  flip_or_rotate_prob = 0.25
+  data_augmentation = 0.75

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -42,3 +42,4 @@ torchvision==0.2.1
 tqdm==4.23.4
 urllib3==1.22
 Werkzeug==0.14.1
+rio_tiler==1.0a7

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -20,7 +20,7 @@ more-itertools==4.2.0
 numpy==1.14.4
 opencv-contrib-python==3.4.1.15
 osmium==2.14.1
-Pillow==5.1.0
+Pillow-simd==5.3.0.post0
 pluggy==0.6.0
 py==1.5.3
 pyparsing==2.2.0

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -37,7 +37,7 @@ six==1.11.0
 snuggs==1.4.1
 supermercado==0.0.5
 toml==0.9.4
-torch==0.4.0
+torch==0.4.1
 torchvision==0.2.1
 tqdm==4.23.4
 urllib3==1.22

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -28,7 +28,7 @@ pyproj==1.9.5.1
 pytest==3.6.1
 python-dateutil==2.7.3
 pytz==2018.4
-rasterio==1.0b1
+rasterio==1.0.9
 requests==2.18.4
 Rtree==0.8.3
 scipy==1.1.0

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -20,7 +20,7 @@ more-itertools==4.2.0
 numpy==1.14.4
 opencv-contrib-python==3.4.1.15
 osmium==2.14.1
-Pillow==5.3.0
+Pillow-simd==5.3.0
 pluggy==0.6.0
 py==1.5.3
 pyparsing==2.2.0

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -42,4 +42,3 @@ torchvision==0.2.1
 tqdm==4.23.4
 urllib3==1.22
 Werkzeug==0.14.1
-rio_tiler==1.0a7

--- a/deps/requirements-lock.txt
+++ b/deps/requirements-lock.txt
@@ -20,7 +20,7 @@ more-itertools==4.2.0
 numpy==1.14.4
 opencv-contrib-python==3.4.1.15
 osmium==2.14.1
-Pillow-simd==5.3.0.post0
+Pillow==5.3.0
 pluggy==0.6.0
 py==1.5.3
 pyparsing==2.2.0

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -17,3 +17,4 @@ rtree
 pyproj
 toml
 pytest
+rio_tiler

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,6 +1,6 @@
 torchvision
 numpy
-pillow
+pillow-simd
 scipy
 opencv-contrib-python
 tqdm

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -17,4 +17,3 @@ rtree
 pyproj
 toml
 pytest
-rio_tiler

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,6 +1,6 @@
 torchvision
 numpy
-pillow-simd
+pillow
 scipy
 opencv-contrib-python
 tqdm
@@ -10,7 +10,7 @@ geojson
 mercantile
 osmium
 matplotlib
-rasterio>=1.0a12
+rasterio
 supermercado
 shapely
 rtree

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -6,7 +6,7 @@ FROM ubuntu:16.04
 # See: https://github.com/skvark/opencv-python/issues/90
 RUN apt-get update -qq && \
     apt-get install -qq -y -o quiet=1 \
-    python3 python3-dev python3-tk python3-pip build-essential libboost-python-dev libexpat1-dev zlib1g-dev libbz2-dev libspatialindex-dev libsm6
+    python3 python3-dev python3-tk python3-pip build-essential libboost-python-dev libexpat1-dev zlib1g-dev libbz2-dev libspatialindex-dev libsm6 libwebp-dev libjpeg-turbo8-dev
 
 WORKDIR /app
 ADD . /app

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -6,7 +6,7 @@ FROM nvidia/cuda:9.1-cudnn7-runtime-ubuntu16.04
 # See: https://github.com/skvark/opencv-python/issues/90
 RUN apt-get update -qq && \
     apt-get install -qq -y -o quiet=1 \
-    python3 python3-dev python3-tk python3-pip build-essential libboost-python-dev libexpat1-dev zlib1g-dev libbz2-dev libspatialindex-dev libsm6
+    python3 python3-dev python3-tk python3-pip build-essential libboost-python-dev libexpat1-dev zlib1g-dev libbz2-dev libspatialindex-dev libsm6 libwebp-dev libjpeg-turbo8-dev
 
 WORKDIR /app
 ADD . /app

--- a/robosat/colors.py
+++ b/robosat/colors.py
@@ -99,7 +99,7 @@ def continuous_palette_for_color(color, bins=256):
 def complementary_palette(palette):
 
     comp_palette = []
-    colors = [palette[i:i+3] for i in range(0, len(palette), 3)]
+    colors = [palette[i : i + 3] for i in range(0, len(palette), 3)]
 
     for color in colors:
         r, g, b = [v for v in color]

--- a/robosat/colors.py
+++ b/robosat/colors.py
@@ -93,3 +93,16 @@ def continuous_palette_for_color(color, bins=256):
     assert len(palette) // 3 == bins
 
     return palette
+
+
+def complementary_palette(palette):
+
+    comp_palette = []
+    colors = [palette[i:i+3] for i in range(0, len(palette), 3)]
+
+    for color in colors:
+        r, g, b = [v for v in color]
+        h, s, v = colorsys.rgb_to_hsv(r, g, b)
+        comp_palette.extend(map(int, colorsys.hsv_to_rgb((h + 0.5) % 1, s, v)))
+
+    return comp_palette

--- a/robosat/colors.py
+++ b/robosat/colors.py
@@ -43,7 +43,7 @@ class Mapbox(Enum):
     pink = _rgb("#ed6498")
 
 
-def make_palette(*colors, colormap=False):
+def make_palette(*colors):
     """Builds a PIL-compatible color palette from color names.
 
     Args:
@@ -53,15 +53,7 @@ def make_palette(*colors, colormap=False):
     assert 0 < len(colors) <= 256
     rgbs = [Mapbox[color].value for color in colors]
 
-    if colormap:
-        palette = np.zeros((256, 1, 3), np.uint8)
-        for i in range(len(colors)):
-            r, g, b = rgbs[i]
-            palette[i, 0, :] = b, g, r
-    else:
-        palette = list(sum(rgbs, ()))
-
-    return palette
+    return list(sum(rgbs, ()))
 
 
 def color_string_to_rgb(color):
@@ -77,7 +69,7 @@ def color_string_to_rgb(color):
     return [*map(int, color.split(","))]
 
 
-def continuous_palette_for_color(color, bins=256, colormap=False):
+def continuous_palette_for_color(color, bins=256):
     """Creates a continuous color palette based on a single color.
 
     Args:
@@ -95,14 +87,11 @@ def continuous_palette_for_color(color, bins=256, colormap=False):
     h, s, v = colorsys.rgb_to_hsv(r, g, b)
 
     assert 0 < bins <= 256
-    palette = np.zeros((256, 1, 3), np.uint8) if colormap else list()
 
+    palette = []
     for i in range(bins):
         r, g, b = [int(v * 255) for v in colorsys.hsv_to_rgb(h, (1 / bins) * (i + 1), v)]
-        if colormap:
-            palette[i, 0, :] = b, g, r
-        else:
-            palette.extend(r, g, b)
+        palette.extend(r, g, b)
 
     return palette
 

--- a/robosat/datasets.py
+++ b/robosat/datasets.py
@@ -8,6 +8,8 @@ See: http://pytorch.org/docs/0.3.1/data.html
 import torch
 from PIL import Image
 import torch.utils.data
+import cv2
+import numpy as np
 
 from robosat.tiles import tiles_from_slippy_map, buffer_tile_image
 
@@ -17,7 +19,7 @@ class SlippyMapTiles(torch.utils.data.Dataset):
     """Dataset for images stored in slippy map format.
     """
 
-    def __init__(self, root, transform=None):
+    def __init__(self, root, mode, transform=None):
         super().__init__()
 
         self.tiles = []
@@ -25,13 +27,19 @@ class SlippyMapTiles(torch.utils.data.Dataset):
 
         self.tiles = [(tile, path) for tile, path in tiles_from_slippy_map(root)]
         self.tiles.sort(key=lambda tile: tile[0])
+        self.mode = mode
 
     def __len__(self):
         return len(self.tiles)
 
     def __getitem__(self, i):
         tile, path = self.tiles[i]
-        image = Image.open(path)
+
+        if self.mode == "image":
+            image = cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
+
+        elif self.mode == "mask":
+            image = np.array(Image.open(path).convert("P"))
 
         if self.transform is not None:
             image = self.transform(image)
@@ -40,42 +48,35 @@ class SlippyMapTiles(torch.utils.data.Dataset):
 
 
 # Multiple Slippy Map directories.
-# Think: one with images, one with masks, one with rasterized traces.
 class SlippyMapTilesConcatenation(torch.utils.data.Dataset):
     """Dataset to concate multiple input images stored in slippy map format.
     """
 
-    def __init__(self, inputs, target, joint_transform=None):
+    def __init__(self, input, target, joint_transform=None):
         super().__init__()
 
         # No transformations in the `SlippyMapTiles` instead joint transformations in getitem
         self.joint_transform = joint_transform
 
-        self.inputs = [SlippyMapTiles(inp) for inp in inputs]
-        self.target = SlippyMapTiles(target)
+        self.target = SlippyMapTiles(target, mode="mask")
+        self.input = SlippyMapTiles(input, mode="image")
 
-        assert len(set([len(dataset) for dataset in self.inputs])) == 1, "same number of tiles in all images"
-        assert len(self.target) == len(self.inputs[0]), "same number of tiles in images and label"
+        assert len(self.input) == len(self.target), "same number of tiles in images and label"
 
     def __len__(self):
         return len(self.target)
 
     def __getitem__(self, i):
-        # at this point all transformations are applied and we expect to work with raw tensors
-        inputs = [dataset[i] for dataset in self.inputs]
 
-        images = [image for image, _ in inputs]
-        tiles = [tile for _, tile in inputs]
-
+        image, image_tile = self.input[i]
         mask, mask_tile = self.target[i]
 
-        assert len(set(tiles)) == 1, "all images are for the same tile"
-        assert tiles[0] == mask_tile, "image tile is the same as label tile"
+        assert image_tile == mask_tile, "image tile is the same as label tile"
 
         if self.joint_transform is not None:
-            images, mask = self.joint_transform(images, mask)
+            image, mask = self.joint_transform(image, mask)
 
-        return torch.cat(images, dim=0), mask, tiles
+        return image, mask, image_tile[0]
 
 
 # Todo: once we have the SlippyMapDataset this dataset should wrap
@@ -113,7 +114,7 @@ class BufferedSlippyMapDirectory(torch.utils.data.Dataset):
 
     def __getitem__(self, i):
         tile, path = self.tiles[i]
-        image = buffer_tile_image(tile, self.tiles, overlap=self.overlap, tile_size=self.size)
+        image = np.array(buffer_tile_image(tile, self.tiles, overlap=self.overlap, tile_size=self.size))
 
         if self.transform is not None:
             image = self.transform(image)

--- a/robosat/log.py
+++ b/robosat/log.py
@@ -10,9 +10,9 @@ class Log:
     """Create a log instance on a log file
     """
 
-    def __init__(self, path, out=sys.stdout):
+    def __init__(self, path, out=sys.stdout, mode="a"):
         self.out = out
-        self.fp = open(path, "a")
+        self.fp = open(path, mode)
         assert self.fp, "Unable to open log file"
 
     """Log a new message to the opened log file, and optionnaly on stdout or stderr too

--- a/robosat/metrics.py
+++ b/robosat/metrics.py
@@ -54,7 +54,13 @@ class Metrics:
         Returns:
           The foreground Intersection over Union score for all observations seen so far.
         """
-        return self.tp / (self.tp + self.fn + self.fp)
+
+        try:
+            iou = self.tp / (self.tp + self.fn + self.fp)
+        except ZeroDivisionError:
+            iou = float("Inf")
+
+        return iou
 
     def get_mcc(self):
         """Retrieves the Matthew's Coefficient Correlation score.
@@ -62,9 +68,15 @@ class Metrics:
         Returns:
           The Matthew's Coefficient Correlation score for all observations seen so far.
         """
-        return (self.tp * self.tn - self.fp * self.fn) / math.sqrt(
-            (self.tp + self.fp) * (self.tp + self.fn) * (self.tn + self.fp) * (self.tn + self.fn)
-        )
+
+        try:
+            mcc = (self.tp * self.tn - self.fp * self.fn) / math.sqrt(
+                (self.tp + self.fp) * (self.tp + self.fn) * (self.tn + self.fp) * (self.tn + self.fn)
+            )
+        except ZeroDivisionError:
+            mcc = float("Inf")
+
+        return mcc
 
 
 # Todo:

--- a/robosat/metrics.py
+++ b/robosat/metrics.py
@@ -46,7 +46,13 @@ class Metrics:
         Returns:
           The mean Intersection over Union score for all observations seen so far.
         """
-        return np.nanmean([self.tn / (self.tn + self.fn + self.fp), self.tp / (self.tp + self.fn + self.fp)])
+
+        try:
+            miou = np.nanmean([self.tn / (self.tn + self.fn + self.fp), self.tp / (self.tp + self.fn + self.fp)])
+        except ZeroDivisionError:
+            miou = float("Inf")
+
+        return miou
 
     def get_fg_iou(self):
         """Retrieves the foreground Intersection over Union score.

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -161,7 +161,7 @@ def adjacent_tile_image(tile, dx, dy, tiles):
     except KeyError:
         return None
 
-    assert path[-5] == ".webp" # OpenCV AFAIK not handling PNG Palette
+    assert path[-5:] == ".webp" # OpenCV AFAIK not handling PNG Palette
     return cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
 
 

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -140,11 +140,11 @@ def tiles_from_csv(path):
             yield mercantile.Tile(*map(int, row))
 
 
-def adjacent_tile(tile, dx, dy, tiles):
-    """Retrieves an adjacent tile from a tile store.
+def adjacent_tile_image(tile, dx, dy, tiles):
+    """Retrieves an adjacent tile image from a tile store.
 
     Args:
-      tile: the original tile to get an adjacent tile for.
+      tile: the original tile to get an adjacent tile image for.
       dx: the offset in tile x direction.
       dy: the offset in tile y direction.
       tiles: the tile store to get tiles from; must support `__getitem__` with tiles.
@@ -161,6 +161,7 @@ def adjacent_tile(tile, dx, dy, tiles):
     except KeyError:
         return None
 
+    assert path[-5] == ".webp" # OpenCV AFAIK not handling PNG Palette
     return cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
 
 
@@ -184,15 +185,15 @@ def buffer_tile_image(tile, tiles, overlap, tile_size):
     x, y, z = map(int, [tile.x, tile.y, tile.z])
 
     # 3x3 matrix (upper, center, bottom) x (left, center, right)
-    ul = adjacent_tile(tile, -1, -1, tiles)
-    uc = adjacent_tile(tile, +0, -1, tiles)
-    ur = adjacent_tile(tile, +1, -1, tiles)
-    cl = adjacent_tile(tile, -1, +0, tiles)
-    cc = adjacent_tile(tile, +0, +0, tiles)
-    cr = adjacent_tile(tile, +1, +0, tiles)
-    bl = adjacent_tile(tile, -1, +1, tiles)
-    bc = adjacent_tile(tile, +0, +1, tiles)
-    br = adjacent_tile(tile, +1, +1, tiles)
+    ul = adjacent_tile_image(tile, -1, -1, tiles)
+    uc = adjacent_tile_image(tile, +0, -1, tiles)
+    ur = adjacent_tile_image(tile, +1, -1, tiles)
+    cl = adjacent_tile_image(tile, -1, +0, tiles)
+    cc = adjacent_tile_image(tile, +0, +0, tiles)
+    cr = adjacent_tile_image(tile, +1, +0, tiles)
+    bl = adjacent_tile_image(tile, -1, +1, tiles)
+    bc = adjacent_tile_image(tile, +0, +1, tiles)
+    br = adjacent_tile_image(tile, +1, +1, tiles)
 
     ts = tile_size
     o = overlap

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -13,7 +13,8 @@ import io
 import os
 
 from PIL import Image
-from pyproj import Proj, transform
+from rasterio.warp import transform
+from rasterio.crs import CRS
 import mercantile
 
 
@@ -54,7 +55,7 @@ def tile_to_bbox(tile):
     """
 
     west, south, east, north = mercantile.bounds(tile)
-    x, y = transform(Proj("+init=EPSG:4326"), Proj("+init=EPSG:3857"), [west, east], [north, south])
+    x, y = transform(CRS.from_epsg(4326), CRS.from_epsg(3857), [west, east], [north, south])
 
     return [min(x), min(y), max(x), max(y)]
 

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -13,6 +13,7 @@ import io
 import os
 
 from PIL import Image
+from pyproj import Proj, transform
 import mercantile
 
 
@@ -40,6 +41,22 @@ def pixel_to_location(tile, dx, dy):
     lat = lerp(south, north, dy)
 
     return lon, lat
+
+
+def tile_to_bbox(tile):
+    """Convert a tile to bbox coordinates
+
+    Args:
+      tile: the mercantile tile
+
+    Returns:
+       Tile's bbox coordinates (expressed in EPSG:3857)
+    """
+
+    west, south, east, north = mercantile.bounds(tile)
+    x, y = transform(Proj("+init=EPSG:4326"), Proj("+init=EPSG:3857"), [west, east], [north, south])
+
+    return [min(x), min(y), max(x), max(y)]
 
 
 def fetch_image(session, url, timeout=10):

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -161,7 +161,7 @@ def adjacent_tile_image(tile, dx, dy, tiles):
     except KeyError:
         return None
 
-    assert path[-5:] == ".webp" # OpenCV AFAIK not handling PNG Palette
+    assert path[-5:] == ".webp"  # OpenCV AFAIK not handling PNG Palette
     return cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
 
 

--- a/robosat/tiles.py
+++ b/robosat/tiles.py
@@ -203,43 +203,28 @@ def buffer_tile_image(tile, tiles, overlap, tile_size, nodata=0):
     center = Image.open(path).convert("RGB")
     composite.paste(center, box=(overlap, overlap))
 
-    top_left = adjacent_tile(tile, -1, -1, tiles)
-    top_right = adjacent_tile(tile, +1, -1, tiles)
-    bottom_left = adjacent_tile(tile, -1, +1, tiles)
-    bottom_right = adjacent_tile(tile, +1, +1, tiles)
-
-    top = adjacent_tile(tile, 0, -1, tiles)
-    left = adjacent_tile(tile, -1, 0, tiles)
-    bottom = adjacent_tile(tile, 0, +1, tiles)
-    right = adjacent_tile(tile, +1, 0, tiles)
+    # 3x3 matrix (upper, center, bottom) x (left, center, right)
+    ul = adjacent_tile(tile, -1, -1, tiles)
+    ur = adjacent_tile(tile, +1, -1, tiles)
+    bl = adjacent_tile(tile, -1, +1, tiles)
+    br = adjacent_tile(tile, +1, +1, tiles)
+    uc = adjacent_tile(tile, +0, -1, tiles)
+    cl = adjacent_tile(tile, -1, +0, tiles)
+    bc = adjacent_tile(tile, +0, +1, tiles)
+    cr = adjacent_tile(tile, +1, +0, tiles)
 
     def maybe_stitch(maybe_tile, composite_box, tile_box):
         if maybe_tile:
             stitch_image(composite, composite_box, maybe_tile, tile_box)
 
-    maybe_stitch(top_left, (0, 0, overlap, overlap), (tile_size - overlap, tile_size - overlap, tile_size, tile_size))
-    maybe_stitch(
-        top_right, (tile_size + overlap, 0, composite_size, overlap), (0, tile_size - overlap, overlap, tile_size)
-    )
-    maybe_stitch(
-        bottom_left,
-        (0, composite_size - overlap, overlap, composite_size),
-        (tile_size - overlap, 0, tile_size, overlap),
-    )
-    maybe_stitch(
-        bottom_right,
-        (composite_size - overlap, composite_size - overlap, composite_size, composite_size),
-        (0, 0, overlap, overlap),
-    )
-    maybe_stitch(top, (overlap, 0, composite_size - overlap, overlap), (0, tile_size - overlap, tile_size, tile_size))
-    maybe_stitch(left, (0, overlap, overlap, composite_size - overlap), (tile_size - overlap, 0, tile_size, tile_size))
-    maybe_stitch(
-        bottom,
-        (overlap, composite_size - overlap, composite_size - overlap, composite_size),
-        (0, 0, tile_size, overlap),
-    )
-    maybe_stitch(
-        right, (composite_size - overlap, overlap, composite_size, composite_size - overlap), (0, 0, overlap, tile_size)
-    )
+    o = overlap
+    maybe_stitch(ul, (0, 0, o, o), (tile_size - o, tile_size - o, tile_size, tile_size))
+    maybe_stitch(ur, (tile_size + o, 0, composite_size, o), (0, tile_size - o, o, tile_size))
+    maybe_stitch(bl, (0, composite_size - o, o, composite_size), (tile_size - o, 0, tile_size, o))
+    maybe_stitch(br, (composite_size - o, composite_size - o, composite_size, composite_size), (0, 0, o, o))
+    maybe_stitch(uc, (o, 0, composite_size - o, o), (0, tile_size - o, tile_size, tile_size))
+    maybe_stitch(cl, (0, o, o, composite_size - o), (tile_size - o, 0, tile_size, tile_size))
+    maybe_stitch(bc, (o, composite_size - o, composite_size - o, composite_size), (0, 0, tile_size, o))
+    maybe_stitch(cr, (composite_size - o, o, composite_size, composite_size - o), (0, 0, o, tile_size))
 
     return composite

--- a/robosat/tools/__main__.py
+++ b/robosat/tools/__main__.py
@@ -16,6 +16,7 @@ from robosat.tools import (
     rasterize,
     serve,
     subset,
+    tile,
     train,
     weights,
 )
@@ -27,6 +28,7 @@ def add_parsers():
 
     # Add your tool's entry point below.
 
+    tile.add_parser(subparser)
     extract.add_parser(subparser)
     cover.add_parser(subparser)
     download.add_parser(subparser)

--- a/robosat/tools/compare.py
+++ b/robosat/tools/compare.py
@@ -29,7 +29,7 @@ def add_parser(subparser):
     parser.add_argument("--dataset", type=str, help="path to dataset configuration file, (for diff and list modes)")
     parser.add_argument("--leaflet", type=str, help="leaflet client base url")
     parser.add_argument("--minimum_fg", type=float, default=0.0, help="skip if foreground ratio below, [0-100]")
-    parser.add_argument("--minimum_qod", type=float, default=100.0, help="redshift tile if QoD below, [0-100]")
+    parser.add_argument("--minimum_qod", type=float, default=0.0, help="redshift tile if QoD below, [0-100]")
 
     parser.set_defaults(func=main)
 

--- a/robosat/tools/compare.py
+++ b/robosat/tools/compare.py
@@ -20,6 +20,7 @@ def add_parser(subparser):
     parser.add_argument("masks", type=str, nargs="+", help="slippy map directories to read masks from")
     parser.add_argument("--minimum", type=float, default=0.0, help="minimum percentage of mask not background")
     parser.add_argument("--maximum", type=float, default=1.0, help="maximum percentage of mask not background")
+    parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
 
@@ -65,3 +66,6 @@ def main(args):
         os.makedirs(os.path.join(args.out, z, x), exist_ok=True)
         path = os.path.join(args.out, z, x, "{}.png".format(y))
         combined.save(path, optimize=True)
+
+    if args.leaflet:
+        leaflet(args.out, args.leaflet, images, ".png")

--- a/robosat/tools/compare.py
+++ b/robosat/tools/compare.py
@@ -1,71 +1,145 @@
 import os
+import sys
+import math
+import torch
 import argparse
 
 from PIL import Image
 from tqdm import tqdm
 import numpy as np
 
+from robosat.colors import make_palette, complementary_palette
 from robosat.tiles import tiles_from_slippy_map
+from robosat.config import load_config
+from robosat.metrics import Metrics
+from robosat.utils import leaflet
+from robosat.log import Log
 
 
 def add_parser(subparser):
     parser = subparser.add_parser(
-        "compare",
-        help="compare images, labels and masks side by side",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        "compare", help="compare images, labels and masks", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument("out", type=str, help="directory to save visualizations to")
-    parser.add_argument("images", type=str, help="directory to read slippy map images from")
-    parser.add_argument("labels", type=str, help="directory to read slippy map labels from")
-    parser.add_argument("masks", type=str, nargs="+", help="slippy map directories to read masks from")
-    parser.add_argument("--minimum", type=float, default=0.0, help="minimum percentage of mask not background")
-    parser.add_argument("--maximum", type=float, default=1.0, help="maximum percentage of mask not background")
+    parser.add_argument("out", type=str, help="directory to save output to (or path in list mode)")
+    parser.add_argument("--images", type=str, help="directory to read slippy map images from")
+    parser.add_argument("--labels", type=str, help="directory to read slippy map labels from")
+    parser.add_argument("--masks", type=str, help="directory to read slippy map masks from")
+    parser.add_argument("--dirs", type=str, nargs="+", help="slippy map directories to compares (in side mode)")
+    parser.add_argument("--mode", type=str, default="side", help="compare mode (e.g side, diff or list)")
+    parser.add_argument("--dataset", type=str, help="path to dataset configuration file, (for diff and list modes)")
     parser.add_argument("--leaflet", type=str, help="leaflet client base url")
+    parser.add_argument("--minimum_fg", type=float, default=0.0, help="skip if foreground ratio below, [0-100]")
+    parser.add_argument("--minimum_qod", type=float, default=100.0, help="redshift tile if QoD below, [0-100]")
 
     parser.set_defaults(func=main)
 
 
+def compare(mask, label, classes):
+
+    # TODO: Still binary class centric
+
+    metrics = Metrics(classes)
+    metrics.add(torch.from_numpy(label), torch.from_numpy(mask), is_prob=False)
+    fg_iou = metrics.get_fg_iou()
+
+    fg_ratio = 100 * max(np.sum(mask != 0), np.sum(label != 0)) / mask.size
+    dist = 0.0 if math.isnan(fg_iou) else 1.0 - fg_iou
+
+    qod = 100 - (dist * (math.log(fg_ratio + 1.0) + np.finfo(float).eps) * (100 / math.log(100)))
+    qod = 0.0 if qod < 0.0 else qod  # Corner case prophilaxy
+
+    return dist, fg_ratio, qod
+
+
 def main(args):
-    images = tiles_from_slippy_map(args.images)
 
-    for tile, path in tqdm(list(images), desc="Compare", unit="image", ascii=True):
-        x, y, z = list(map(str, tile))
+    if args.mode == "side":
+        if not args.dirs or len(args.dirs) < 2:
+            sys.exit("Error: In side mode, you must provide at least two directories")
 
-        image = Image.open(path).convert("RGB")
-        label = Image.open(os.path.join(args.labels, z, x, "{}.png".format(y))).convert("P")
-        assert image.size == label.size
+        tiles = tiles_from_slippy_map(args.dirs[0])
 
-        keep = False
-        masks = []
-        for path in args.masks:
-            mask = Image.open(os.path.join(path, z, x, "{}.png".format(y))).convert("P")
-            assert image.size == mask.size
-            masks.append(mask)
+        for tile, path in tqdm(list(tiles), desc="Compare", unit="image", ascii=True):
 
-            # TODO: The calculation below does not work for multi-class.
-            percentage = np.sum(np.array(mask) != 0) / np.prod(image.size)
+            width, heigh = Image.open(path).size
+            side = Image.new(mode="RGB", size=(len(args.dirs) * width, height))
 
-            # Keep this image when percentage is within required threshold.
-            if percentage >= args.minimum and percentage <= args.maximum:
-                keep = True
+            x, y, z = list(map(str, tile))
 
-        if not keep:
-            continue
+            for i, dir in enumerate(args.dirs):
+                try:
+                    img = Image.open(os.path.join(dir, z, x, "{}.png".format(y)))
+                except:
+                    img = Image.open(os.path.join(dir, z, x, "{}.webp".format(y))).convert("RGB")
 
-        width, height = image.size
+                assert image.size == img.size
+                side.paste(img, box=(i * width, 0))
 
-        # Columns for image, label and all the masks.
-        columns = 2 + len(masks)
-        combined = Image.new(mode="RGB", size=(columns * width, height))
+            os.makedirs(os.path.join(args.out, z, x), exist_ok=True)
+            path = os.path.join(args.out, z, x, "{}.webp".format(y))
+            side.save(path, optimize=True)
 
-        combined.paste(image, box=(0 * width, 0))
-        combined.paste(label, box=(1 * width, 0))
-        for i, mask in enumerate(masks):
-            combined.paste(mask, box=((2 + i) * width, 0))
+    elif args.mode == "diff":
+        if not args.images or not args.labels or not args.masks or not args.dataset:
+            sys.exit("Error: in diff mode, you must provide images, labels and masks directories, and dataset path")
 
-        os.makedirs(os.path.join(args.out, z, x), exist_ok=True)
-        path = os.path.join(args.out, z, x, "{}.png".format(y))
-        combined.save(path, optimize=True)
+        dataset = load_config(args.dataset)
+        classes = dataset["common"]["classes"]
+        colors = dataset["common"]["colors"]
+        assert len(classes) == len(colors), "classes and colors coincide"
+        assert len(colors) == 2, "only binary models supported right now"
 
-    if args.leaflet:
-        leaflet(args.out, args.leaflet, images, ".png")
+        palette_mask = make_palette(colors[0], colors[1])
+        palette_label = complementary_palette(palette_mask)
+
+        images = tiles_from_slippy_map(args.images)
+
+        for tile, path in tqdm(list(images), desc="Compare", unit="image", ascii=True):
+            x, y, z = list(map(str, tile))
+            os.makedirs(os.path.join(args.out, str(z), str(x)), exist_ok=True)
+
+            image = Image.open(path).convert("RGB")
+            label = Image.open(os.path.join(args.labels, z, x, "{}.png".format(y)))
+            mask = Image.open(os.path.join(args.masks, z, x, "{}.png".format(y)))
+
+            assert image.size == label.size == mask.size
+            assert label.getbands() == mask.getbands() == tuple("P")
+
+            dist, fg_ratio, qod = compare(np.array(mask), np.array(label), classes)
+
+            image = np.array(image) * 0.7
+            if args.minimum_fg < fg_ratio and qod < args.minimum_qod:
+                image += np.array(Image.new("RGB", label.size, (int(255 * 0.3), 0, 0)))
+
+            mask.putpalette(palette_mask)
+            label.putpalette(palette_label)
+            mask = np.array(mask.convert("RGB"))
+            label = np.array(label.convert("RGB"))
+
+            diff = Image.fromarray(np.uint8((image + mask + label) / 3.0))
+            diff.save(os.path.join(args.out, str(z), str(x), "{}.webp".format(y)), optimize=True)
+
+        if args.leaflet:
+            tiles = [tile for tile, _ in tiles_from_slippy_map(args.images)]
+            leaflet(args.out, args.leaflet, tiles, "webp")
+
+    elif args.mode == "list":
+        if not args.labels or not args.masks or not args.dataset:
+            sys.exit("In list mode, you must provide labels and masks directories, and dataset path")
+
+        dataset = load_config(args.dataset)
+        masks = tiles_from_slippy_map(args.masks)
+        os.makedirs(os.path.basename(args.out), exist_ok=True)
+        log = Log(args.out, out=None, mode="w")
+
+        for tile, path in tqdm(list(masks), desc="Compare", unit="image", ascii=True):
+            x, y, z = list(map(str, tile))
+            mask = Image.open(os.path.join(args.masks, z, x, "{}.png".format(y)))
+            label = Image.open(os.path.join(args.labels, z, x, "{}.png".format(y)))
+
+            assert label.size == mask.size
+            assert label.getbands() == mask.getbands() == tuple("P")
+
+            dist, fg_ratio, qod = compare(np.array(mask), np.array(label), dataset["common"]["classes"])
+            if args.minimum_fg < fg_ratio and qod < args.minimum_qod:
+                log.log("{},{},{}\t\t{:.3f}\t\t{:.3f}\t\t{:.3f}".format(x, y, z, dist, fg_ratio, qod))

--- a/robosat/tools/cover.py
+++ b/robosat/tools/cover.py
@@ -1,37 +1,49 @@
 import argparse
 import csv
 import json
+import sys
 
 from supermercado import burntiles
+from mercantile import tiles
 from tqdm import tqdm
 
 
 def add_parser(subparser):
     parser = subparser.add_parser(
         "cover",
-        help="generates tiles covering GeoJSON features",
+        help="generates tiles covering GeoJSON features or lat/lon Bbox",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     parser.add_argument("--zoom", type=int, required=True, help="zoom level of tiles")
-    parser.add_argument("features", type=str, help="path to GeoJSON features")
+    parser.add_argument("--features", type=str, help="path to GeoJSON features")
+    parser.add_argument("--bbox", type=str, help="bbox expressed in lat/lon (i.e EPSG:4326)")
     parser.add_argument("out", type=str, help="path to csv file to store tiles in")
 
     parser.set_defaults(func=main)
 
 
 def main(args):
-    with open(args.features) as f:
-        features = json.load(f)
 
-    tiles = []
+    cover = []
 
-    for feature in tqdm(features["features"], ascii=True, unit="feature"):
-        tiles.extend(map(tuple, burntiles.burn([feature], args.zoom).tolist()))
+    if args.features:
+        with open(args.features) as f:
+            features = json.load(f)
 
-    # tiles can overlap for multiple features; unique tile ids
-    tiles = list(set(tiles))
+        for feature in tqdm(features["features"], ascii=True, unit="feature"):
+            cover.extend(map(tuple, burntiles.burn([feature], args.zoom).tolist()))
+
+        # tiles can overlap for multiple features; unique tile ids
+        cover = list(set(cover))
+
+    elif args.bbox:
+        west, south, east, north = map(float, args.bbox.split(","))
+        cover = tiles(west, south, east, north, args.zoom)
+
+    else:
+        sys.exit("You have to provide either a GeoJson features file, or a lat/lon bbox")
 
     with open(args.out, "w") as fp:
         writer = csv.writer(fp)
-        writer.writerows(tiles)
+        writer.writerows(cover)

--- a/robosat/tools/download.py
+++ b/robosat/tools/download.py
@@ -9,6 +9,7 @@ from PIL import Image
 from tqdm import tqdm
 
 from robosat.tiles import tiles_from_csv, fetch_image, tile_to_bbox
+from robosat.utils import leaflet
 
 
 def add_parser(subparser):
@@ -25,6 +26,7 @@ def add_parser(subparser):
     parser.add_argument("--timeout", type=int, default=10, help="server request timeout (in seconds)")
     parser.add_argument("tiles", type=str, help="path to .csv tiles file")
     parser.add_argument("out", type=str, help="path to slippy map directory for storing tiles")
+    parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
 
@@ -87,3 +89,6 @@ def main(args):
             for tile, url, ok in executor.map(worker, tiles):
                 if not ok:
                     print("Warning:\n {} failed, skipping.\n {}\n".format(tile, url), file=sys.stderr)
+
+    if args.leaflet:
+        leaflet(args.out, args.leaflet, tiles, args.ext)

--- a/robosat/tools/download.py
+++ b/robosat/tools/download.py
@@ -50,7 +50,7 @@ def main(args):
                 path = os.path.join(args.out, z, x, "{}.{}".format(y, args.ext))
 
                 if os.path.isfile(path):
-                    return tile, True
+                    return tile, None, True
 
                 if args.type == "XYZ":
                     url = args.url.format(x=tile.x, y=tile.y, z=tile.z)
@@ -64,13 +64,13 @@ def main(args):
                 res = fetch_image(session, url, args.timeout)
 
                 if not res:
-                    return tile, False
+                    return tile, url, False
 
                 try:
                     image = Image.open(res)
                     image.save(path, optimize=True)
                 except OSError:
-                    return tile, False
+                    return tile, url, False
 
                 tock = time.monotonic()
 
@@ -82,8 +82,8 @@ def main(args):
 
                 progress.update()
 
-                return tile, True
+                return tile, url, True
 
-            for tile, ok in executor.map(worker, tiles):
+            for tile, url, ok in executor.map(worker, tiles):
                 if not ok:
-                    print("Warning: {} failed, skipping".format(tile), file=sys.stderr)
+                    print("Warning:\n {} failed, skipping.\n {}\n".format(tile, url), file=sys.stderr)

--- a/robosat/tools/download.py
+++ b/robosat/tools/download.py
@@ -68,9 +68,10 @@ def main(args):
                 elif args.type == "WMS":
                     xmin, ymin, xmax, ymax = tile_to_bbox(tile)
                     url = args.url.format(xmin=xmin, ymin=ymin, xmax=xmax, ymax=ymax)
+                else:
+                    return tile, None, False
 
                 res = fetch_image(session, url, args.timeout)
-
                 if not res:
                     return tile, url, False
 

--- a/robosat/tools/export.py
+++ b/robosat/tools/export.py
@@ -4,6 +4,7 @@ import os
 import torch
 import torch.onnx
 import torch.autograd
+import torch.nn as nn
 
 from robosat.config import load_config
 from robosat.unet import UNet
@@ -11,13 +12,15 @@ from robosat.unet import UNet
 
 def add_parser(subparser):
     parser = subparser.add_parser(
-        "export", help="exports model in ONNX format", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        "export", help="exports or prunes model", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
     parser.add_argument("--dataset", type=str, required=True, help="path to dataset configuration file")
+    parser.add_argument("--export_channels", type=int, help="export channels to use (keep the first ones)")
+    parser.add_argument("--type", type=str, default="onnx", help="output type, i.e onnx or pth")
     parser.add_argument("--image_size", type=int, default=512, help="image size to use for model")
     parser.add_argument("--checkpoint", type=str, required=True, help="model checkpoint to load")
-    parser.add_argument("model", type=str, help="path to save ONNX GraphProto .pb model to")
+    parser.add_argument("out", type=str, help="path to save export model to")
 
     parser.set_defaults(func=main)
 
@@ -25,18 +28,33 @@ def add_parser(subparser):
 def main(args):
     dataset = load_config(args.dataset)
 
-    num_classes = len(dataset["common"]["classes"])
-    net = UNet(num_classes)
+    if args.type == "onnx":
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        # Workaround: PyTorch ONNX, DataParallel with GPU issue, cf https://github.com/pytorch/pytorch/issues/5315
 
-    os.environ["CUDA_VISIBLE_DEVICES"] = "" # to be sure GPUs if any won't be used
+    num_classes = len(dataset["common"]["classes"])
+    num_channels = len(dataset["common"]["channels"])
+    export_channels = num_channels if not args.export_channels else args.export_channels
+    assert num_channels >= export_channels, "Will be hard indeed, to export more channels than thoses dataset provide"
+
     def map_location(storage, _):
         return storage.cpu()
 
+    net = UNet(num_classes, num_channels=num_channels).to("cpu")
     chkpt = torch.load(args.checkpoint, map_location=map_location)
     net = torch.nn.DataParallel(net)
     net.load_state_dict(chkpt["state_dict"])
 
-    # Todo: make input channels configurable, not hard-coded to three channels for RGB
-    batch = torch.autograd.Variable(torch.randn(1, 3, args.image_size, args.image_size))
+    if export_channels < num_channels:
+        weights = torch.zeros((64, export_channels, 7, 7))
+        weights.data = net.module.resnet.conv1.weight.data[:, :export_channels, :, :]
+        net.module.resnet.conv1 = nn.Conv2d(num_channels, 64, kernel_size=7, stride=2, padding=3, bias=False)
+        net.module.resnet.conv1.weight = nn.Parameter(weights)
 
-    torch.onnx.export(net, batch, args.model)
+    if args.type == "onnx":
+        batch = torch.autograd.Variable(torch.randn(1, export_channels, args.image_size, args.image_size))
+        torch.onnx.export(net, batch, args.out)
+
+    elif args.type == "pth":
+        states = {"epoch": chkpt["epoch"], "state_dict": net.state_dict(), "optimizer": chkpt["optimizer"]}
+        torch.save(states, args.out)

--- a/robosat/tools/export.py
+++ b/robosat/tools/export.py
@@ -1,5 +1,6 @@
 import argparse
 
+import os
 import torch
 import torch.onnx
 import torch.autograd
@@ -27,6 +28,7 @@ def main(args):
     num_classes = len(dataset["common"]["classes"])
     net = UNet(num_classes)
 
+    os.environ["CUDA_VISIBLE_DEVICES"] = "" # to be sure GPUs if any won't be used
     def map_location(storage, _):
         return storage.cpu()
 

--- a/robosat/tools/masks.py
+++ b/robosat/tools/masks.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from robosat.tiles import tiles_from_slippy_map
 from robosat.colors import make_palette
+from robosat.utils import leaflet
 
 
 def add_parser(subparser):
@@ -21,6 +22,7 @@ def add_parser(subparser):
     parser.add_argument("masks", type=str, help="slippy map directory to save masks to")
     parser.add_argument("probs", type=str, nargs="+", help="slippy map directories with class probabilities")
     parser.add_argument("--weights", type=float, nargs="+", help="weights for weighted average soft-voting")
+    parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
 
@@ -67,6 +69,10 @@ def main(args):
 
         path = os.path.join(args.masks, str(z), str(x), str(y) + ".png")
         out.save(path, optimize=True)
+
+    if args.leaflet:
+        tiles = [tile for tile, _ in list(tiles_from_slippy_map(args.probs[0]))]
+        leaflet(args.masks, args.leaflet, tiles, ".png")
 
 
 def softvote(probs, axis=0, weights=None):

--- a/robosat/tools/masks.py
+++ b/robosat/tools/masks.py
@@ -72,7 +72,7 @@ def main(args):
 
     if args.leaflet:
         tiles = [tile for tile, _ in list(tiles_from_slippy_map(args.probs[0]))]
-        leaflet(args.masks, args.leaflet, tiles, ".png")
+        leaflet(args.masks, args.leaflet, tiles, "png")
 
 
 def softvote(probs, axis=0, weights=None):

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -18,6 +18,7 @@ from robosat.unet import UNet
 from robosat.config import load_config
 from robosat.colors import continuous_palette_for_color, make_palette
 from robosat.transforms import ImageToTensor
+from robosat.utils import leaflet
 
 
 def add_parser(subparser):
@@ -37,6 +38,7 @@ def add_parser(subparser):
     parser.add_argument("--model", type=str, required=True, help="path to model configuration file")
     parser.add_argument("--dataset", type=str, required=True, help="path to dataset configuration file")
     parser.add_argument("--masks_output", action="store_true", help="output masks rather than probs")
+    parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
 
@@ -113,3 +115,6 @@ def main(args):
                 path = os.path.join(args.probs, str(z), str(x), str(y) + ".png")
 
                 out.save(path, optimize=True)
+
+        if args.leaflet:
+            leaflet(args.probs, args.leaflet, tiles, ".png")

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -31,7 +31,7 @@ def add_parser(subparser):
     parser.add_argument("--checkpoint", type=str, required=True, help="model checkpoint to load")
     parser.add_argument("--overlap", type=int, default=32, help="tile pixel overlap to predict on")
     parser.add_argument("--tile_size", type=int, required=True, help="tile size for slippy map tiles")
-    parser.add_argument("--workers", type=int, default=1, help="number of workers pre-processing images")
+    parser.add_argument("--workers", type=int, default=0, help="number of workers pre-processing images")
     parser.add_argument("tiles", type=str, help="directory to read slippy map image tiles from")
     parser.add_argument("probs", type=str, help="directory to save slippy map probability masks to")
     parser.add_argument("--model", type=str, required=True, help="path to model configuration file")

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -90,12 +90,12 @@ def main(args):
                 prob = directory.unbuffer(prob)
 
                 assert prob.shape[0] == 2, "single channel requires binary model"
-                assert np.allclose(np.sum(prob, axis=0), 1.), "single channel requires probabilities to sum up to one"
+                assert np.allclose(np.sum(prob, axis=0), 1.0), "single channel requires probabilities to sum up to one"
 
                 foreground = prob[1:, :, :]
                 image = np.around(foreground) if args.masks_output else np.digitize(foreground, np.linspace(0, 1, 256))
 
-                out = Image.fromarray(image.squeeze().astype("uint8"), mode="P")
+                out = Image.fromarray(image.squeeze().astype(np.uint8), mode="P")
                 out.putpalette(palette)
 
                 os.makedirs(os.path.join(args.probs, str(z), str(x)), exist_ok=True)

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -17,7 +17,7 @@ from robosat.datasets import BufferedSlippyMapDirectory
 from robosat.unet import UNet
 from robosat.config import load_config
 from robosat.colors import continuous_palette_for_color
-from robosat.transforms import ConvertImageMode, ImageToTensor
+from robosat.transforms import ImageToTensor
 
 
 def add_parser(subparser):
@@ -70,7 +70,7 @@ def main(args):
 
     mean, std = [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
 
-    transform = Compose([ConvertImageMode(mode="RGB"), ImageToTensor(), Normalize(mean=mean, std=std)])
+    transform = Compose([ImageToTensor(), Normalize(mean=mean, std=std)])
 
     directory = BufferedSlippyMapDirectory(args.tiles, transform=transform, size=args.tile_size, overlap=args.overlap)
     loader = DataLoader(directory, batch_size=args.batch_size, num_workers=args.workers)

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -91,18 +91,18 @@ def main(args):
                 # we predicted on buffered tiles; now get back probs for original image
                 prob = directory.unbuffer(prob)
 
-                # Quantize the floating point probabilities in [0,1] to [0,255] and store
-                # a single-channel `.png` file with a continuous color palette attached.
-
                 assert prob.shape[0] == 2, "single channel requires binary model"
                 assert np.allclose(np.sum(prob, axis=0), 1.), "single channel requires probabilities to sum up to one"
+
                 foreground = prob[1:, :, :]
 
                 if args.masks_output:
+                    # Quantize the floating point prob in [0,1] to {0,1} with a fixed palette attached
                     image = np.around(foreground)
                     palette = make_palette("denim", "orange")
 
                 else:
+                    # Quantize the floating point prob in [0,1] to [0,255] with a continuous color palette attached
                     image = np.digitize(foreground, np.linspace(0, 1, 256))
                     palette = continuous_palette_for_color("pink", 256)
 

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -117,4 +117,4 @@ def main(args):
                 out.save(path, optimize=True)
 
         if args.leaflet:
-            leaflet(args.probs, args.leaflet, tiles, ".png")
+            leaflet(args.probs, args.leaflet, tiles, "png")

--- a/robosat/tools/predict.py
+++ b/robosat/tools/predict.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from PIL import Image
 
 from robosat.datasets import BufferedSlippyMapDirectory
+from robosat.tiles import tiles_from_slippy_map
 from robosat.unet import UNet
 from robosat.config import load_config
 from robosat.colors import continuous_palette_for_color, make_palette
@@ -116,5 +117,5 @@ def main(args):
 
                 out.save(path, optimize=True)
 
-        if args.leaflet:
-            leaflet(args.probs, args.leaflet, tiles, "png")
+    if args.leaflet:
+        leaflet(args.probs, args.leaflet, [tile for tile, _ in tiles_from_slippy_map(args.tiles)], "png")

--- a/robosat/tools/rasterize.py
+++ b/robosat/tools/rasterize.py
@@ -47,6 +47,7 @@ def feature_to_mercator(feature):
     """
     # Ref: https://gist.github.com/dnomadb/5cbc116aacc352c7126e779c29ab7abe
 
+    # FIXME: We assume that GeoJSON input coordinates can't be anything else than EPSG:4326
     if feature["geometry"]["type"] == "Polygon":
         xys = (zip(*ring) for ring in feature["geometry"]["coordinates"])
         xys = (list(zip(*transform(CRS.from_epsg(4326), CRS.from_epsg(3857), *xy))) for xy in xys)
@@ -150,4 +151,4 @@ def main(args):
         out.save(os.path.join(out_path, "{}.png".format(tile.y)), optimize=True)
 
     if args.leaflet:
-        leaflet(args.out, args.leaflet, tiles_from_csv(args.tiles), "png")
+        leaflet(args.out, args.leaflet, [tile for tile in tiles_from_csv(args.tiles)], "png")

--- a/robosat/tools/rasterize.py
+++ b/robosat/tools/rasterize.py
@@ -19,6 +19,7 @@ from shapely.geometry import shape, mapping
 from robosat.config import load_config
 from robosat.colors import make_palette
 from robosat.tiles import tiles_from_csv
+from robosat.utils import leaflet
 
 
 def add_parser(subparser):
@@ -32,6 +33,7 @@ def add_parser(subparser):
     parser.add_argument("--dataset", type=str, required=True, help="path to dataset configuration file")
     parser.add_argument("--zoom", type=int, required=True, help="zoom level of tiles")
     parser.add_argument("--size", type=int, default=512, help="size of rasterized image tiles in pixels")
+    parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
 
@@ -123,3 +125,6 @@ def main(args):
         os.makedirs(out_path, exist_ok=True)
 
         out.save(os.path.join(out_path, "{}.png".format(tile.y)), optimize=True)
+
+    if args.leaflet:
+        leaflet(args.out, args.leaflet, args.tiles, ".png")

--- a/robosat/tools/rasterize.py
+++ b/robosat/tools/rasterize.py
@@ -127,4 +127,4 @@ def main(args):
         out.save(os.path.join(out_path, "{}.png".format(tile.y)), optimize=True)
 
     if args.leaflet:
-        leaflet(args.out, args.leaflet, args.tiles, ".png")
+        leaflet(args.out, args.leaflet, tiles_from_csv(args.tiles), "png")

--- a/robosat/tools/serve.py
+++ b/robosat/tools/serve.py
@@ -63,7 +63,7 @@ def tile(z, x, y):
     if not res:
         abort(500)
 
-    image = cv2.cvtColor(cv2.imread(res), cv2.COLOR_BGR2RGB)
+    image = cv2.imdecode(np.asarray(bytearray(res.read()), dtype=np.uint8), cv2.COLOR_BGR2RGB)
 
     mask = predictor.segment(image)
 

--- a/robosat/tools/serve.py
+++ b/robosat/tools/serve.py
@@ -12,6 +12,7 @@ from torchvision.transforms import Compose, Normalize
 
 import mercantile
 import requests
+import cv2
 from PIL import Image
 from flask import Flask, send_file, render_template, abort
 
@@ -19,7 +20,7 @@ from robosat.tiles import fetch_image
 from robosat.unet import UNet
 from robosat.config import load_config
 from robosat.colors import make_palette
-from robosat.transforms import ConvertImageMode, ImageToTensor
+from robosat.transforms import ImageToTensor
 
 """
 Simple tile server running a segmentation model on the fly.
@@ -62,7 +63,7 @@ def tile(z, x, y):
     if not res:
         abort(500)
 
-    image = Image.open(res)
+    image = cv2.cvtColor(cv2.imread(res), cv2.COLOR_BGR2RGB)
 
     mask = predictor.segment(image)
 
@@ -152,7 +153,7 @@ class Predictor:
         with torch.no_grad():
             mean, std = [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
 
-            transform = Compose([ConvertImageMode(mode="RGB"), ImageToTensor(), Normalize(mean=mean, std=std)])
+            transform = Compose([ImageToTensor(), Normalize(mean=mean, std=std)])
             image = transform(image)
 
             batch = image.unsqueeze(0).to(self.device)

--- a/robosat/tools/subset.py
+++ b/robosat/tools/subset.py
@@ -31,11 +31,10 @@ def main(args):
         if tile not in tiles:
             continue
 
-        # The extension also includes the period.
-        extension = os.path.splitext(src)[1]
+        extension = os.path.splitext(src)[1][1:]
 
         os.makedirs(os.path.join(args.out, str(tile.z), str(tile.x)), exist_ok=True)
-        dst = os.path.join(args.out, str(tile.z), str(tile.x), "{}{}".format(tile.y, extension))
+        dst = os.path.join(args.out, str(tile.z), str(tile.x), "{}.{}".format(tile.y, extension))
 
         shutil.copyfile(src, dst)
 

--- a/robosat/tools/subset.py
+++ b/robosat/tools/subset.py
@@ -5,6 +5,7 @@ import shutil
 from tqdm import tqdm
 
 from robosat.tiles import tiles_from_slippy_map, tiles_from_csv
+from robosat.utils import leaflet
 
 
 def add_parser(subparser):
@@ -16,6 +17,7 @@ def add_parser(subparser):
     parser.add_argument("images", type=str, help="directory to read slippy map image tiles from for filtering")
     parser.add_argument("tiles", type=str, help="csv to filter images by")
     parser.add_argument("out", type=str, help="directory to save filtered images to")
+    parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
 
@@ -29,10 +31,13 @@ def main(args):
         if tile not in tiles:
             continue
 
-        # The extention also includes the period.
-        extention = os.path.splitext(src)[1]
+        # The extension also includes the period.
+        extension = os.path.splitext(src)[1]
 
         os.makedirs(os.path.join(args.out, str(tile.z), str(tile.x)), exist_ok=True)
-        dst = os.path.join(args.out, str(tile.z), str(tile.x), "{}{}".format(tile.y, extention))
+        dst = os.path.join(args.out, str(tile.z), str(tile.x), "{}{}".format(tile.y, extension))
 
         shutil.copyfile(src, dst)
+
+    if args.leaflet:
+        leaflet(args.out, args.leaflet, tiles, extension)

--- a/robosat/tools/templates/leaflet.html
+++ b/robosat/tools/templates/leaflet.html
@@ -15,7 +15,7 @@
   <div id="mapid" style="width:100%; height:100vh;"></div>
   <script>
     var m = L.map("mapid", {zoomControl: false, boxZoom: false, scrollWheelZoom: false}).setView({{center}}, {{zoom}});
-    L.tileLayer("{{base_url}}/{z}/{x}/{y}{{ext}}").addTo(m);
+    L.tileLayer("{{base_url}}/{z}/{x}/{y}.{{ext}}").addTo(m);
   </script>
 </body>
 </html>

--- a/robosat/tools/templates/leaflet.html
+++ b/robosat/tools/templates/leaflet.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>RoboSat LeafLet Client</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
+        integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
+	crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"
+	  integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA=="
+	  crossorigin=""></script>
+</head>
+<body>
+  <div id="mapid" style="width:100%; height:100vh;"></div>
+  <script>
+    var m = L.map("mapid", {zoomControl: false, boxZoom: false, scrollWheelZoom: false}).setView({{center}}, {{zoom}});
+    L.tileLayer("{{base_url}}/{z}/{x}/{y}{{ext}}").addTo(m);
+  </script>
+</body>
+</html>

--- a/robosat/tools/templates/leaflet.html
+++ b/robosat/tools/templates/leaflet.html
@@ -14,8 +14,9 @@
 <body>
   <div id="mapid" style="width:100%; height:100vh;"></div>
   <script>
-    var m = L.map("mapid", {zoomControl: false, boxZoom: false, scrollWheelZoom: false}).setView({{center}}, {{zoom}});
+    var m = L.map("mapid").setView({{center}}, {{zoom}});
     L.tileLayer("{{base_url}}/{z}/{x}/{y}.{{ext}}").addTo(m);
+    L.geoJSON({{grid}}, {style: {"color": "#cc0099", "opacity": 0.1, "fillOpacity": 0}}).addTo(m);
   </script>
 </body>
 </html>

--- a/robosat/tools/templates/map.html
+++ b/robosat/tools/templates/map.html
@@ -45,7 +45,7 @@ mapboxgl.accessToken = '{{ token }}';
 
 var beforeMap = new mapboxgl.Map({
   container: 'before',
-  center: [-84.37, 33.75],
+  center: [45.5, 5.5],
   zoom: 18,
   minZoom: 5,
   maxZoom: 20,
@@ -55,7 +55,7 @@ var beforeMap = new mapboxgl.Map({
 
 var afterMap = new mapboxgl.Map({
   container: 'after',
-  center: [-84.37, 33.75],
+  center: [45.5, 5.5],
   zoom: 18,
   minZoom: 5,
   maxZoom: 20,
@@ -71,7 +71,7 @@ afterMap.on('load', function() {
     'type': 'raster',
     'source': {
       'type': 'raster',
-      'tiles': [ 'http://127.0.0.1:5000/{z}/{x}/{y}.png' ],
+      'tiles': [ 'http://127.0.0.1/rs/gl/validation/probs/{z}/{x}/{y}.png' ],
       'tileSize': {{ size }}
     }
   });

--- a/robosat/tools/templates/map.html
+++ b/robosat/tools/templates/map.html
@@ -45,7 +45,7 @@ mapboxgl.accessToken = '{{ token }}';
 
 var beforeMap = new mapboxgl.Map({
   container: 'before',
-  center: [45.5, 5.5],
+  center: [-84.37, 33.75],
   zoom: 18,
   minZoom: 5,
   maxZoom: 20,
@@ -55,7 +55,7 @@ var beforeMap = new mapboxgl.Map({
 
 var afterMap = new mapboxgl.Map({
   container: 'after',
-  center: [45.5, 5.5],
+  center: [-84.37, 33.75],
   zoom: 18,
   minZoom: 5,
   maxZoom: 20,
@@ -71,7 +71,7 @@ afterMap.on('load', function() {
     'type': 'raster',
     'source': {
       'type': 'raster',
-      'tiles': [ 'http://127.0.0.1/rs/gl/validation/probs/{z}/{x}/{y}.png' ],
+      'tiles': [ 'http://127.0.0.1:5000/{z}/{x}/{y}.png' ],
       'tileSize': {{ size }}
     }
   });

--- a/robosat/tools/tile.py
+++ b/robosat/tools/tile.py
@@ -51,7 +51,6 @@ def main(args):
         assert len(colors) == 2, "only binary models supported right now"
 
     try:
-        os.environ["GDAL_CACHEMAX"] = "50%"  # rasterio Env don't (yet) handle % settings
         raster = rasterio_open(args.raster)
         w, s, e, n = bounds = transform_bounds(raster.crs, "EPSG:4326", *raster.bounds)
         transform, _, _ = calculate_default_transform(raster.crs, "EPSG:3857", raster.width, raster.height, *bounds)

--- a/robosat/tools/tile.py
+++ b/robosat/tools/tile.py
@@ -43,7 +43,7 @@ def main(args):
         assert len(colors) == 2, "only binary models supported right now"
 
     bounds = tiler.bounds(args.raster)["bounds"]
-    tiles = ([[x, y] for x, y, z in mercantile.tiles(*bounds + [[args.zoom]])])
+    tiles = [[x, y] for x, y, z in mercantile.tiles(*bounds + [[args.zoom]])]
 
     if args.no_edges:
         edges_x = (min(tiles, key=lambda xy: xy[0])[0]), (max(tiles, key=lambda xy: xy[0])[0])
@@ -71,9 +71,9 @@ def main(args):
 
             # GeoTiff could be 16 or 32bits
             if data.dtype == "uint16":
-                 data = np.uint8(data / 256)
+                data = np.uint8(data / 256)
             elif data.dtype == "uint32":
-                 data = np.uint8(data / (256 * 256))
+                data = np.uint8(data / (256 * 256))
 
             if C == 1:
                 Image.fromarray(np.squeeze(data, axis=0), mode="L").save(path + ".png", optimize=True)

--- a/robosat/tools/tile.py
+++ b/robosat/tools/tile.py
@@ -14,7 +14,7 @@ from robosat.colors import make_palette
 
 def add_parser(subparser):
     parser = subparser.add_parser(
-        "tile", help="tile a raster image", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        "tile", help="tile a raster image or label", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
     parser.add_argument("raster", type=str, help="path to the raster to tile")

--- a/robosat/tools/tile.py
+++ b/robosat/tools/tile.py
@@ -68,7 +68,7 @@ def main(args):
             data[data < args.label_thresold] = 0
             data[data >= args.label_thresold] = 1
 
-            ext = ".png"
+            ext = "png"
             img = Image.fromarray(np.squeeze(data, axis=0), mode="P")
             img.putpalette(make_palette(colors[0], colors[1]))
             img.save(path + ext, optimize=True)
@@ -83,10 +83,10 @@ def main(args):
                 data = np.uint8(data / (256 * 256))
 
             if C == 1:
-                ext = ".png"
+                ext = "png"
                 Image.fromarray(np.squeeze(data, axis=0), mode="L").save(path + ext, optimize=True)
             elif C == 3:
-                ext = ".webp"
+                ext = "webp"
                 Image.fromarray(np.swapaxes(data, 0, 2), mode="RGB").save(path + ext, optimize=True)
 
         else:

--- a/robosat/tools/tile.py
+++ b/robosat/tools/tile.py
@@ -23,9 +23,9 @@ def add_parser(subparser):
     parser.add_argument("--size", type=int, default=512, help="size of tiles side in pixels")
     parser.add_argument("--zoom", type=int, required=True, help="zoom level of tiles")
     parser.add_argument("--type", type=str, default="image", help="image or label tiling")
-    parser.add_argument("--dataset", type=str, help="path to dataset configuration file, needed for label tiling")
+    parser.add_argument("--dataset", type=str, help="path to dataset configuration file, mandatory for label tiling")
     parser.add_argument("--no_edges", action="store_true", help="skip to generate edges tiles")
-    parser.add_argument("--label_thresold", type=int, default=1, help="label value thresold")
+    parser.add_argument("--label_threshold", type=int, default=1, help="label value threshold")
     parser.add_argument("--leaflet", type=str, help="leaflet client base url")
 
     parser.set_defaults(func=main)
@@ -37,8 +37,7 @@ def main(args):
         try:
             dataset = load_config(args.dataset)
         except:
-            print("Error: Unable to load DataSet config file", file=sys.stderr)
-            sys.exit()
+            sys.exit("Error: Unable to load DataSet config file")
 
         classes = dataset["common"]["classes"]
         colors = dataset["common"]["colors"]
@@ -46,32 +45,32 @@ def main(args):
         assert len(colors) == 2, "only binary models supported right now"
 
     bounds = tiler.bounds(args.raster)["bounds"]
-    tiles = [[x, y] for x, y, z in mercantile.tiles(*bounds + [[args.zoom]])]
+    tiles = [mercantile.Tile(x=x, y=y, z=z) for x, y, z in mercantile.tiles(*bounds + [[args.zoom]])]
 
     if args.no_edges:
         edges_x = (min(tiles, key=lambda xy: xy[0])[0]), (max(tiles, key=lambda xy: xy[0])[0])
         edges_y = (min(tiles, key=lambda xy: xy[1])[1]), (max(tiles, key=lambda xy: xy[1])[1])
-        tiles = [[x, y] for x, y in tiles if x not in edges_x and y not in edges_y]
+        tiles = [mercantile.Tile(x=x, y=y, z=z) for x, y, z in tiles if x not in edges_x and y not in edges_y]
         assert len(tiles), "Error: Nothing left to tile, once the edges removed"
 
-    for x, y in tqdm(tiles, desc="Tiling", unit="tile", ascii=True):
+    for tile in tqdm(tiles, desc="Tiling", unit="tile", ascii=True):
 
-        os.makedirs(os.path.join(args.out, str(args.zoom), str(x)), exist_ok=True)
-        path = os.path.join(args.out, str(args.zoom), str(x), str(y))
-        data = tiler.tile(args.raster, x, y, args.zoom, tilesize=args.size)[0]
+        os.makedirs(os.path.join(args.out, str(args.zoom), str(tile.x)), exist_ok=True)
+        path = os.path.join(args.out, str(args.zoom), str(tile.x), str(tile.y))
+        data = tiler.tile(args.raster, tile.x, tile.y, args.zoom, tilesize=args.size)[0]
 
         C, W, H = data.shape
 
         if args.type == "label":
             assert C == 1, "Error: Label raster input should be 1 band"
 
-            data[data < args.label_thresold] = 0
-            data[data >= args.label_thresold] = 1
+            data[data < args.label_threshold] = 0
+            data[data >= args.label_threshold] = 1
 
             ext = "png"
             img = Image.fromarray(np.squeeze(data, axis=0), mode="P")
             img.putpalette(make_palette(colors[0], colors[1]))
-            img.save(path + ext, optimize=True)
+            img.save("{}.{}".format(path, ext), optimize=True)
 
         elif args.type == "image":
             assert C == 1 or C == 3, "Error: Image raster input should be either 1 or 3 bands"
@@ -84,14 +83,13 @@ def main(args):
 
             if C == 1:
                 ext = "png"
-                Image.fromarray(np.squeeze(data, axis=0), mode="L").save(path + ext, optimize=True)
+                Image.fromarray(np.squeeze(data, axis=0), mode="L").save("{}.{}".format(path, ext), optimize=True)
             elif C == 3:
                 ext = "webp"
-                Image.fromarray(np.swapaxes(data, 0, 2), mode="RGB").save(path + ext, optimize=True)
+                Image.fromarray(np.moveaxis(data, 0, 2), mode="RGB").save("{}.{}".format(path, ext), optimize=True)
 
         else:
-            print("Error: Unknown type, should be either 'image' or 'label'", file=sys.stderr)
-            sys.exit()
+            sys.exit("Error: Unknown type, should be either 'image' or 'label'")
 
     if args.leaflet:
         leaflet(args.out, args.leaflet, tiles, ext)

--- a/robosat/tools/tile.py
+++ b/robosat/tools/tile.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import argparse
+from tqdm import tqdm
+
+import numpy as np
+from PIL import Image
+
+import mercantile
+from rio_tiler import main as tiler
+from robosat.config import load_config
+from robosat.colors import make_palette
+
+
+def add_parser(subparser):
+    parser = subparser.add_parser(
+        "tile", help="tile a raster image", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("raster", type=str, help="path to the raster to tile")
+    parser.add_argument("out", type=str, help="directory to write tiles")
+    parser.add_argument("--size", type=int, default=512, help="size of tiles side in pixels")
+    parser.add_argument("--zoom", type=int, required=True, help="zoom level of tiles")
+    parser.add_argument("--type", type=str, default="image", help="image or label tiling")
+    parser.add_argument("--dataset", type=str, help="path to dataset configuration file, needed for label tiling")
+    parser.add_argument("--no_edges", type=bool, help="don't generate edges tiles")
+
+    parser.set_defaults(func=main)
+
+
+def main(args):
+
+    if args.type == "label":
+        try:
+            dataset = load_config(args.dataset)
+        except:
+            print("Error: Unable to load DataSet config file", file=sys.stderr)
+            sys.exit()
+
+        classes = dataset["common"]["classes"]
+        colors = dataset["common"]["colors"]
+        assert len(classes) == len(colors), "classes and colors coincide"
+        assert len(colors) == 2, "only binary models supported right now"
+
+    bounds = tiler.bounds(args.raster)["bounds"]
+    tiles = ([[x, y] for x, y, z in mercantile.tiles(*bounds + [[args.zoom]])])
+
+    if args.no_edges:
+        edges_x = (min(tiles, key=lambda xy: xy[0])[0]), (max(tiles, key=lambda xy: xy[0])[0])
+        edges_y = (min(tiles, key=lambda xy: xy[1])[1]), (max(tiles, key=lambda xy: xy[1])[1])
+        tiles = [[x, y] for x, y in tiles if x not in edges_x and y not in edges_y]
+        assert len(tiles), "Error: Nothing left to tile, once remove the edges"
+
+    for x, y in tqdm(tiles, desc="Tiling", unit="tile", ascii=True):
+
+        os.makedirs(os.path.join(args.out, str(args.zoom), str(x)), exist_ok=True)
+        path = os.path.join(args.out, str(args.zoom), str(x), str(y))
+        data = tiler.tile(args.raster, x, y, args.zoom, tilesize=args.size)[0]
+
+        C, W, H = data.shape
+
+        if args.type == "label":
+            assert C == 1, "Error: Label raster input should be 1 band"
+
+            img = Image.fromarray(np.squeeze(data, axis=0), mode="P")
+            img.putpalette(make_palette(colors[0], colors[1]))
+            img.save(path + ".png", optimize=True)
+
+        elif args.type == "image":
+            assert C == 1 or C == 3, "Error: Image raster input should be either 1 or 3 bands"
+
+            # GeoTiff could be 16 or 32bits
+            if data.dtype == "uint16":
+                 data = np.uint8(data / 256)
+            elif data.dtype == "uint32":
+                 data = np.uint8(data / (256 * 256))
+
+            if C == 1:
+                Image.fromarray(np.squeeze(data, axis=0), mode="L").save(path + ".png", optimize=True)
+            elif C == 3:
+                Image.fromarray(data, mode="RGB").save(path + ".webp", optimize=True)

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -56,6 +56,7 @@ def main(args):
     model = load_config(args.model)
     dataset = load_config(args.dataset)
 
+    os.makedirs(model["common"]["checkpoint"], exist_ok=True)
     log = Log(os.path.join(model["common"]["checkpoint"], "log"))
 
     if torch.cuda.is_available():
@@ -65,8 +66,6 @@ def main(args):
     else:
         device = torch.device("cpu")
         log.log("RoboSat - training on CPU, with {} workers", format(args.workers))
-
-    os.makedirs(model["common"]["checkpoint"], exist_ok=True)
 
     num_classes = len(dataset["common"]["classes"])
     net = UNet(num_classes)

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -248,6 +248,7 @@ def validate(loader, num_classes, device, net, criterion):
 
 def get_dataset_loaders(model, dataset, workers):
     target_size = (model["common"]["image_size"],) * 2
+    target_size = tuple([size * model["opt"]["upscale_factor"] for size in target_size])
     batch_size = model["common"]["batch_size"]
     path = dataset["common"]["dataset"]
 
@@ -257,7 +258,6 @@ def get_dataset_loaders(model, dataset, workers):
         [
             JointTransform(ConvertImageMode("RGB"), ConvertImageMode("P")),
             JointTransform(Resize(target_size, Image.BILINEAR), Resize(target_size, Image.NEAREST)),
-            JointTransform(CenterCrop(target_size), CenterCrop(target_size)),
             JointRandomHorizontalFlip(0.5),
             JointRandomRotation(0.5, 90),
             JointRandomRotation(0.5, 90),

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -75,10 +75,10 @@ def main(args):
     if model["common"]["cuda"]:
         torch.backends.cudnn.benchmark = True
 
-    try:
-        weight = torch.Tensor(dataset["weights"]["values"])
-    except KeyError:
-        if model["opt"]["loss"] in ("CrossEntropy", "mIoU", "Focal"):
+    if model["opt"]["loss"] in ("CrossEntropy", "mIoU", "Focal"):
+        try:
+            weight = torch.Tensor(dataset["weights"]["values"])
+        except KeyError:
             sys.exit("Error: The loss function used, need dataset weights values")
 
     optimizer = Adam(net.parameters(), lr=model["opt"]["lr"], weight_decay=model["opt"]["decay"])

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -120,6 +120,7 @@ def main(args):
     log.log("--- Hyper Parameters on Dataset: {} ---".format(dataset["common"]["dataset"]))
     log.log("Batch Size:\t {}".format(model["common"]["batch_size"]))
     log.log("Image Size:\t {}".format(model["common"]["image_size"]))
+    log.log("Image Upscale:\t {}".format(model["opt"]["image_upscale"]))
     log.log("Learning Rate:\t {}".format(model["opt"]["lr"]))
     log.log("Weight Decay:\t {}".format(model["opt"]["decay"]))
     log.log("Loss function:\t {}".format(model["opt"]["loss"]))
@@ -248,7 +249,7 @@ def validate(loader, num_classes, device, net, criterion):
 
 def get_dataset_loaders(model, dataset, workers):
     target_size = (model["common"]["image_size"],) * 2
-    target_size = tuple([size * model["opt"]["upscale_factor"] for size in target_size])
+    target_size = tuple([size * model["opt"]["image_upscale"] for size in target_size])
     batch_size = model["common"]["batch_size"]
     path = dataset["common"]["dataset"]
 

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -48,7 +48,7 @@ def add_parser(subparser):
     parser.add_argument("--dataset", type=str, required=True, help="path to dataset configuration file")
     parser.add_argument("--checkpoint", type=str, required=False, help="path to a model checkpoint (to retrain)")
     parser.add_argument("--resume", type=bool, default=False, help="resume training or fine-tuning (if checkpoint)")
-    parser.add_argument("--workers", type=int, default=1, help="number of workers pre-processing images")
+    parser.add_argument("--workers", type=int, default=0, help="number of workers pre-processing images")
 
     parser.set_defaults(func=main)
 

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -119,8 +119,7 @@ def main(args):
     log.log("--- Hyper Parameters on Dataset: {} ---".format(dataset["common"]["dataset"]))
     log.log("Batch Size:\t\t {}".format(model["common"]["batch_size"]))
     log.log("Image Size:\t\t {}".format(model["common"]["image_size"]))
-    log.log("Image Resize factor:\t {}".format(model["opt"]["image_resize_factor"]))
-    log.log("Flip or Rotate prob:\t {}".format(model["opt"]["flip_or_rotate_prob"]))
+    log.log("Data Augmentation:\t {}".format(model["opt"]["data_augmentation"]))
     log.log("Learning Rate:\t\t {}".format(model["opt"]["lr"]))
     log.log("Weight Decay:\t\t {}".format(model["opt"]["decay"]))
     log.log("Loss function:\t\t {}".format(model["opt"]["loss"]))
@@ -254,8 +253,8 @@ def get_dataset_loaders(model, dataset, workers):
 
     transform = JointCompose(
         [
-            JointResize(model["opt"]["image_resize_factor"]),
-            JointRandomFlipOrRotate(model["opt"]["flip_or_rotate_prob"]),
+            JointResize(model["common"]["image_size"]),
+            JointRandomFlipOrRotate(model["opt"]["data_augmentation"]),
             JointTransform(ImageToTensor(), MaskToTensor()),
             JointTransform(Normalize(mean=mean, std=std), None),
         ]

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -46,7 +46,7 @@ def add_parser(subparser):
     parser.add_argument("--model", type=str, required=True, help="path to model configuration file")
     parser.add_argument("--dataset", type=str, required=True, help="path to dataset configuration file")
     parser.add_argument("--checkpoint", type=str, required=False, help="path to a model checkpoint (to retrain)")
-    parser.add_argument("--resume", type=bool, default=False, help="resume training or fine-tuning (if checkpoint)")
+    parser.add_argument("--resume", action="store_true", help="resume training (imply to provide a checkpoint)")
     parser.add_argument("--workers", type=int, default=0, help="number of workers pre-processing images")
 
     parser.set_defaults(func=main)

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -261,17 +261,19 @@ def get_dataset_loaders(model, dataset, workers):
         ]
     )
 
-    batch_size = model["common"]["batch_size"]
-    path = dataset["common"]["dataset"]
-
     train_dataset = SlippyMapTilesConcatenation(
-        os.path.join(path, "training", "images"), os.path.join(path, "training", "labels"), transform
+        os.path.join(dataset["common"]["dataset"], "training", "images"),
+        os.path.join(dataset["common"]["dataset"], "training", "labels"),
+        joint_transform=transform,
     )
 
     val_dataset = SlippyMapTilesConcatenation(
-        os.path.join(path, "validation", "images"), os.path.join(path, "validation", "labels"), transform
+        os.path.join(dataset["common"]["dataset"], "validation", "images"),
+        os.path.join(dataset["common"]["dataset"], "validation", "labels"),
+        joint_transform=transform,
     )
 
+    batch_size = model["common"]["batch_size"]
     train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, drop_last=True, num_workers=workers)
     val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, drop_last=True, num_workers=workers)
 

--- a/robosat/tools/weights.py
+++ b/robosat/tools/weights.py
@@ -10,7 +10,7 @@ from torchvision.transforms import Compose
 
 from robosat.config import load_config
 from robosat.datasets import SlippyMapTiles
-from robosat.transforms import ConvertImageMode, MaskToTensor
+from robosat.transforms import MaskToTensor
 
 
 def add_parser(subparser):
@@ -29,9 +29,9 @@ def main(args):
     path = dataset["common"]["dataset"]
     num_classes = len(dataset["common"]["classes"])
 
-    train_transform = Compose([ConvertImageMode(mode="P"), MaskToTensor()])
+    train_transform = Compose([MaskToTensor()])
 
-    train_dataset = SlippyMapTiles(os.path.join(path, "training", "labels"), transform=train_transform)
+    train_dataset = SlippyMapTiles(os.path.join(path, "training", "labels"), "mask", transform=train_transform)
 
     n = 0
     counts = np.zeros(num_classes, dtype=np.int64)

--- a/robosat/transforms.py
+++ b/robosat/transforms.py
@@ -28,17 +28,17 @@ class MaskToTensor:
     """Callable to convert an OpenCV H,W image into a PyTorch tensor.
     """
 
-    def __call__(self, tensor):
-        """Converts the image into a tensor.
+    def __call__(self, mask):
+        """Converts the mask into a tensor.
 
         Args:
-          image: the image to convert into a PyTorch tensor.
+          mask: the mask to convert into a PyTorch tensor.
 
         Returns:
           The converted PyTorch tensor.
         """
 
-        return torch.from_numpy(tensor).long()
+        return torch.from_numpy(mask).long()
 
 
 class JointCompose:

--- a/robosat/transforms.py
+++ b/robosat/transforms.py
@@ -2,56 +2,43 @@
 """
 
 import random
-
 import torch
+import cv2
 import numpy as np
-from PIL import Image
-
-import torchvision
 
 
-# Callable to convert a RGB image into a PyTorch tensor.
-ImageToTensor = torchvision.transforms.ToTensor
-
-
-class MaskToTensor:
-    """Callable to convert a PIL image into a PyTorch tensor.
+class ImageToTensor:
+    """Callable to convert a OpenCV H,W,C image into a PyTorch tensor.
     """
 
     def __call__(self, image):
         """Converts the image into a tensor.
 
         Args:
-          image: the PIL image to convert into a PyTorch tensor.
+          image: the image to convert into a PyTorch tensor.
 
         Returns:
           The converted PyTorch tensor.
         """
 
-        return torch.from_numpy(np.array(image, dtype=np.uint8)).long()
+        return torch.from_numpy(np.moveaxis(image, 2, 0)).float()
 
 
-class ConvertImageMode:
-    """Callable to convert a PIL image into a specific image mode (e.g. RGB, P)
+class MaskToTensor:
+    """Callable to convert an OpenCV H,W image into a PyTorch tensor.
     """
 
-    def __init__(self, mode):
-        """Creates an `ConvertImageMode` instance.
+    def __call__(self, tensor):
+        """Converts the image into a tensor.
 
         Args:
-          mode: the PIL image mode string
+          image: the image to convert into a PyTorch tensor.
+
+        Returns:
+          The converted PyTorch tensor.
         """
 
-        self.mode = mode
-
-    def __call__(self, image):
-        """Applies to mode conversion to an image.
-
-        Args:
-          image: the PIL.Image image to transform.
-        """
-
-        return image.convert(self.mode)
+        return torch.from_numpy(tensor).long()
 
 
 class JointCompose:
@@ -67,21 +54,21 @@ class JointCompose:
 
         self.transforms = transforms
 
-    def __call__(self, images, mask):
-        """Applies multiple transformations to the images and the mask at the same time.
+    def __call__(self, image, mask):
+        """Applies multiple transformations to the image and its mask at the same time.
 
         Args:
-          images: the PIL.Image images to transform.
-          mask: the PIL.Image mask to transform.
+          image: the image to transform.
+          mask: the mask to transform.
 
         Returns:
-          The transformed PIL.Image (images, mask) tuple.
+          The transformed (image, mask) tuple.
         """
 
         for transform in self.transforms:
-            images, mask = transform(images, mask)
+            image, mask = transform(image, mask)
 
-        return images, mask
+        return image, mask
 
 
 class JointTransform:
@@ -94,128 +81,109 @@ class JointTransform:
         """Creates an `JointTransform` instance.
 
         Args:
-          image_transform: the transformation to run on the images or `None` for no-op.
+          image_transform: the transformation to run on the image or `None` for no-op.
           mask_transform: the transformation to run on the mask or `None` for no-op.
 
         Returns:
-          The (images, mask) tuple with the transformations applied.
+          The (image, mask) tuple with the transformations applied.
         """
 
         self.image_transform = image_transform
         self.mask_transform = mask_transform
 
-    def __call__(self, images, mask):
-        """Applies the transformations associated with images and their mask.
+    def __call__(self, image, mask):
+        """Applies the transformations associated with image and its mask.
 
         Args:
-          images: the PIL.Image images to transform.
-          mask: the PIL.Image mask to transform.
+          image: the image to transform.
+          mask: the mask to transform.
 
         Returns:
-          The PIL.Image (images, mask) tuple with images and mask transformed.
+          The (image, mask) tuple with the transformations applied.
         """
 
         if self.image_transform is not None:
-            images = [self.image_transform(v) for v in images]
+            image = self.image_transform(image)
 
         if self.mask_transform is not None:
             mask = self.mask_transform(mask)
 
-        return images, mask
+        return image, mask
 
 
-class JointRandomVerticalFlip:
-    """Callable to randomly flip images and its mask top to bottom.
+class JointRandomFlipOrRotate:
+    """Callable to randomly rotate image and its mask.
     """
 
     def __init__(self, p):
-        """Creates an `JointRandomVerticalFlip` instance.
-
-        Args:
-          p: the probability for flipping.
-        """
-
-        self.p = p
-
-    def __call__(self, images, mask):
-        """Randomly flips images and their mask top to bottom.
-
-        Args:
-          images: the PIL.Image image to transform.
-          mask: the PIL.Image mask to transform.
-
-        Returns:
-          The PIL.Image (images, mask) tuple with either images and mask flipped or none of them flipped.
-        """
-
-        if random.random() < self.p:
-            return [v.transpose(Image.FLIP_TOP_BOTTOM) for v in images], mask.transpose(Image.FLIP_TOP_BOTTOM)
-        else:
-            return images, mask
-
-
-class JointRandomHorizontalFlip:
-    """Callable to randomly flip images and their mask left to right.
-    """
-
-    def __init__(self, p):
-        """Creates an `JointRandomHorizontalFlip` instance.
-
-        Args:
-          p: the probability for flipping.
-        """
-
-        self.p = p
-
-    def __call__(self, images, mask):
-        """Randomly flips image and their mask left to right.
-
-        Args:
-          images: the PIL.Image images to transform.
-          mask: the PIL.Image mask to transform.
-
-        Returns:
-          The PIL.Image (images, mask) tuple with either images and mask flipped or none of them flipped.
-        """
-
-        if random.random() < self.p:
-            return [v.transpose(Image.FLIP_LEFT_RIGHT) for v in images], mask.transpose(Image.FLIP_LEFT_RIGHT)
-        else:
-            return images, mask
-
-
-class JointRandomRotation:
-    """Callable to randomly rotate images and their mask.
-    """
-
-    def __init__(self, p, degree):
         """Creates an `JointRandomRotation` instance.
 
         Args:
           p: the probability for rotating.
         """
-
+        assert p >= 0.0 and p <= 1.0, "Probability must be expressed in 0-1 interval"
         self.p = p
 
-        methods = {90: Image.ROTATE_90, 180: Image.ROTATE_180, 270: Image.ROTATE_270}
-
-        if degree not in methods.keys():
-            raise NotImplementedError("We only support multiple of 90 degree rotations for now")
-
-        self.method = methods[degree]
-
-    def __call__(self, images, mask):
-        """Randomly rotates images and their mask.
+    def __call__(self, image, mask):
+        """Randomly rotates or flip image and its mask.
 
         Args:
-          images: the PIL.Image image to transform.
-          mask: the PIL.Image mask to transform.
+          image: the image to transform.
+          mask: the mask to transform.
 
         Returns:
-          The PIL.Image (images, mask) tuple with either images and mask rotated or none of them rotated.
+          The (image, mask) tuple with either image and mask flip or rotated or kept untouched (but synced)
         """
 
-        if random.random() < self.p:
-            return [v.transpose(self.method) for v in images], mask.transpose(self.method)
+        if random.random() > self.p:
+            return image, mask
+
+        transform = random.choice(["Rotate90", "Rotate180", "Rotate270", "HorizontalFlip", "VerticalFlip"])
+
+        if transform == "Rotate90":
+            return cv2.flip(cv2.transpose(image), +1), cv2.flip(cv2.transpose(mask), +1)
+        elif transform == "Rotate180":
+            return cv2.flip(image, -1), cv2.flip(mask, -1)
+        elif transform == "Rotate270":
+            return cv2.flip(cv2.transpose(image), 0), cv2.flip(cv2.transpose(mask), 0)
+        elif transform == "HorizontalFlip":
+            return cv2.flip(image, +1), cv2.flip(mask, +1)
+        elif transform == "VerticalFlip":
+            return cv2.flip(image, 0), cv2.flip(mask, 0)
+
+
+class JointResize:
+    """Callable to resize image and its mask
+    """
+
+    def __init__(self, f):
+        """Creates an `JointResize` instance.
+
+        Args:
+          f: the desired resize factor
+        """
+        assert not (f % 2) or not (int(1 / f) % 2) or f == 1, "Invalid resize factor value"
+        self.f = f
+
+    def __call__(self, image, mask):
+        """Resize image and its mask
+
+        Args:
+          image: the image to transform.
+          mask: the mask to transform.
+
+        Returns:
+          The (image, mask) tuple resized
+        """
+
+        if self.f == 1:
+            return image, mask
+        elif self.f > 1:
+            image_interpolation = cv2.INTER_AREA
         else:
-            return images, mask
+            image_interpolation = cv2.INTER_LINEAR
+
+        return (
+            cv2.resize(image, None, fx=self.f, fy=self.f, interpolation=image_interpolation),
+            cv2.resize(mask, None, fx=self.f, fy=self.f, interpolation=cv2.INTER_NEAREST),
+        )

--- a/robosat/transforms.py
+++ b/robosat/transforms.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 class ImageToTensor:
-    """Callable to convert a OpenCV H,W,C image into a PyTorch tensor.
+    """Callable to convert a NumPy H,W,C image into a PyTorch C,W,H tensor.
     """
 
     def __call__(self, image):
@@ -25,7 +25,7 @@ class ImageToTensor:
 
 
 class MaskToTensor:
-    """Callable to convert an OpenCV H,W image into a PyTorch tensor.
+    """Callable to convert a NumPy H,W image into a PyTorch tensor.
     """
 
     def __call__(self, mask):

--- a/robosat/transforms.py
+++ b/robosat/transforms.py
@@ -156,14 +156,13 @@ class JointResize:
     """Callable to resize image and its mask
     """
 
-    def __init__(self, f):
+    def __init__(self, size):
         """Creates an `JointResize` instance.
 
         Args:
-          f: the desired resize factor
+          size: the desired square side size
         """
-        assert not (f % 2) or not (int(1 / f) % 2) or f == 1, "Invalid resize factor value"
-        self.f = f
+        self.hw = (size, size)
 
     def __call__(self, image, mask):
         """Resize image and its mask
@@ -176,14 +175,14 @@ class JointResize:
           The (image, mask) tuple resized
         """
 
-        if self.f == 1:
-            return image, mask
-        elif self.f > 1:
-            image_interpolation = cv2.INTER_AREA
+        if self.hw == image.shape[0:2]:
+            pass
+        elif self.hw[0] < image.shape[0] and self.hw[1] < image.shape[1]:
+            image = cv2.resize(image, self.hw, interpolation=cv2.INTER_AREA)
         else:
-            image_interpolation = cv2.INTER_LINEAR
+            image = cv2.resize(image, self.hw, interpolation=cv2.INTER_LINEAR)
 
-        return (
-            cv2.resize(image, None, fx=self.f, fy=self.f, interpolation=image_interpolation),
-            cv2.resize(mask, None, fx=self.f, fy=self.f, interpolation=cv2.INTER_NEAREST),
-        )
+        if self.hw != mask.shape:
+            mask = cv2.resize(mask, self.hw, interpolation=cv2.INTER_NEAREST)
+
+        return image, mask

--- a/robosat/utils.py
+++ b/robosat/utils.py
@@ -1,5 +1,5 @@
 import re
-import os 
+import os
 from robosat.tiles import pixel_to_location
 import mercantile
 import json
@@ -37,7 +37,7 @@ def leaflet(out, base_url, tiles, ext):
     leaflet = re.sub("{{grid}}", grid, leaflet)
 
     # Could surely be improve, but for now, took the first tile to center on
-    tile = (list(tiles)[0])
+    tile = list(tiles)[0]
     x, y, z = map(int, [tile.x, tile.y, tile.z])
     leaflet = re.sub("{{zoom}}", str(z), leaflet)
     leaflet = re.sub("{{center}}", str(list(pixel_to_location(tile, 0.5, 0.5))[::-1]), leaflet)

--- a/robosat/utils.py
+++ b/robosat/utils.py
@@ -1,6 +1,8 @@
 import re
 import os 
 from robosat.tiles import pixel_to_location
+import mercantile
+import json
 import matplotlib
 
 matplotlib.use("Agg")
@@ -27,9 +29,12 @@ def plot(out, history):
 
 def leaflet(out, base_url, tiles, ext):
 
+    grid = json.dumps([mercantile.feature(tile) for tile in tiles])
+
     leaflet = open("./robosat/tools/templates/leaflet.html", "r").read()
     leaflet = re.sub("{{base_url}}", base_url, leaflet)
     leaflet = re.sub("{{ext}}", ext, leaflet)
+    leaflet = re.sub("{{grid}}", grid, leaflet)
 
     # Could surely be improve, but for now, took the first tile to center on
     tile = (list(tiles)[0])

--- a/robosat/utils.py
+++ b/robosat/utils.py
@@ -1,3 +1,6 @@
+import re
+import os 
+from robosat.tiles import pixel_to_location
 import matplotlib
 
 matplotlib.use("Agg")
@@ -20,3 +23,20 @@ def plot(out, history):
 
     plt.savefig(out, format="png")
     plt.close()
+
+
+def leaflet(out, base_url, tiles, ext):
+
+    leaflet = open("./robosat/tools/templates/leaflet.html", "r").read()
+    leaflet = re.sub("{{base_url}}", base_url, leaflet)
+    leaflet = re.sub("{{ext}}", ext, leaflet)
+
+    # Could surely be improve, but for now, took the first tile to center on
+    tile = (list(tiles)[0])
+    x, y, z = map(int, [tile.x, tile.y, tile.z])
+    leaflet = re.sub("{{zoom}}", str(z), leaflet)
+    leaflet = re.sub("{{center}}", str(list(pixel_to_location(tile, 0.5, 0.5))[::-1]), leaflet)
+
+    f = open(os.path.join(out, "index.html"), "w", encoding="utf-8")
+    f.write(leaflet)
+    f.close()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -12,17 +12,16 @@ class TestSlippyMapTiles(unittest.TestCase):
     images = "tests/fixtures/images/"
 
     def test_len(self):
-        dataset = SlippyMapTiles(TestSlippyMapTiles.images)
+        dataset = SlippyMapTiles(TestSlippyMapTiles.images, "image")
         self.assertEqual(len(dataset), 3)
 
     def test_getitem(self):
-        dataset = SlippyMapTiles(TestSlippyMapTiles.images)
+        dataset = SlippyMapTiles(TestSlippyMapTiles.images, "image")
         image, tile = dataset[0]
 
         assert tile == mercantile.Tile(69105, 105093, 18)
-        # Inspired by: https://github.com/python-pillow/Pillow/blob/master/Tests/test_image.py#L37-L38
-        self.assertEqual(repr(image)[:45], "<PIL.JpegImagePlugin.JpegImageFile image mode")
-        self.assertEqual(image.size, (512, 512))
+        self.assertEqual(image.size, 512 * 512 * 3)
+        self.assertEqual(image.shape, (512, 512, 3))
 
     def test_getitem_with_transform(self):
         # TODO


### PR DESCRIPTION
A) MultiBands aka #56
    - Switch from PIL to OpenCV for slippy map images (to allow multibands images handling)

    - SlippyMapTileConcatenation produce now an aggregate C,W,H NumPy tensor rather than a list of RGB images

    - First Unet-like encoder layer, could be adjust upon num_channels (so not anymore harcoded 3 but now 1-N)

    - ONNX export tool was updated consequently

    - Defaults weights (before reusing any ImageNet RGB pre trained weights bands) use Xavier initialization

    - Nothing specific was done at this moment on ResNet mean/stdev values (still to explore if/when needed)

    - Dataset configuration file allow channels configuration for bands on each choosen slippymap dir
      and choosen channels are reported in the train ouputs logs

    - Add an experimental option in export tool, to allow to reduce channels, from a pth to an another pth.
      At this stage, allow to make some experiments, on how to reuse ImageNet weights in a MultiBands/Fusion context.
      This point is still an open subject to find best training approach (i.e rather than train from scratch)

    - Nota: still to explore alternate NN topology to deal with multibands
      for example, where extra bands are copied on each Encoder layers (and not only on the first one, as in this PR):
      cf: https://hal.archives-ouvertes.fr/hal-01523573/document


   Data Augmentation
    - Refactored rotate and flip
    - Removed what looks like an useless crop treatment
    - data_augmentation occurence probability (flip or rotate for now) became an hyperparameter in userland
    - Select best resampling resize interpolation as previously, but now also on downsampling
    - To keep in mind that even some basic DataAugmentation as flip/rotate can't be been performed with PyTorch on GPU
      (https://discuss.pytorch.org/t/torch-from-numpy-not-support-negative-strides/3663)


B) Tools:

 Download:
  - Add a WFS and TMS server type handling (XYZ still the default)
  - Timeout could be specified in userland (some WMS performing pre/post-treatments could take times)
  - Use and improve Log handling (e.g giving more information on already downloaded tiles)

 Cover:
  - Add ability to render a cover from a lat/lon bbox, or from a slippy map directory
    (as a consequence the features parameter become optional)

 Predict:
  - Add an option to generate directly masks (rather than probs)
  - Refactor the tile_buffer provider (slightly improve perfs)
  - model parameter is not mandatory anymore (as we use cuda if CUDA_VISIBLE_DEVICES not empty)

 Compare:
  - Full refactor, Compare tool now allow 3 differents modes:
     - side: Close to the previous behaviour (and so the default), but allow 2 to N images to compare (cf #80)
     - diff: Work with images/masks/labels and compute a single diff image for efficient QoD check
     - list: Render a cover with IoU metric on each mask/label couple tiles

 Tile:
  - Add a first tiling tool implementation, to tile either images or labels from a raster,
    performances are decents for a mono process stuff,
    and it's able to deal with no_data borders (by removing the related tiles)

 Rasterize:
  - Refactor the GeoJSON parser, to cleanly handle all GeoJSON surfacic geometries
    (GeometryCollection, MultiPolygon, Polygon) and N-Dimensional GeoJSON coordinates
    Nota: we still blindly assume GeoJSON coordinates inputs are EPSG:4326
  - Use and improve Log handling

 Predict, Subset, Download, Rasterize, Compare, Masks, Tile:
  - Add a leaflet client generation option, to allow an easy slippy map visual inspection


C) Maintenance:

 Bugfixes
  - Fix a ZeroDiv issue, who was still remaning in mIoU metrics

 Performances
  - Switch from Pillow to Pillow-simd (cf https://github.com/uploadcare/pillow-simd)
    Imply recent Intel/AMD proc, but significant perf improvements on PIL treatment stuff (about x6)
    Nota: didn't see a significative difference for RoboSat use case beetwen SSE4 and AVX2 (i.e SSE4 is 'enough')

 Versions stuff
  - Upgrade rasterio version to the latest stable one (1.0.9)
  - nn.functional.sample -> nn.functional.interpolate (to avoid 0.4.1 related warning)

 Credits
  - echoed my name >> AUTHORS.md


D) Userland considerations:
   - channels configuration now mandatory in dataset.toml (as an array of table)
   - data_augmentation ratio and resnet pretrained as new mandatory hyper-parameters in model.toml
   - cuda bool is no longer needed in model.toml (by default use now all CUDA_VISIBLE_DEVICES available)
   - libwebp and libjpeg are mandatory for pillow-simd (so imply updating install doc)
   - In compare tool, maximum parameter was removed (could't imagine a use case) and minimum was rename to minimum_fg
   - In cover tool the features parameter is not anymore a positional (became an optional)


NOTES:
  - Could you Daniel give me a hint how the robosat unit tests are supposed to be launched ?
    It still remains to me unclear, and did'nt yet investigate, on it.

  - Was developped (and so tested) on Cuda 9.2/PyTorch 0.4.1 (single and multi GPU)
    and also quickly cheked on a single GPU Cuda 10/PyTorch 1.0 Nightly build.
    CPU only, have barely not been tested at this point.

  - Dockers cpu and gpu have not been tested at all (cf pillow-simd stuff)

  - Didn't yet find an easy/efficient way to deal with PNG Palette with OpenCV2.
    Could leads to remove Pillow, as OpenCV2 is faster.

  - Code concision is kept with less than ~400 additionnal lines, in the codebase, for this whole PR ^^

  - Thanks in advance Daniel for the coming code review :)
