### PR TITLE
Uses `rs` command as default docker entrypoint

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -20,3 +20,6 @@ RUN python3 -m pip install http://download.pytorch.org/whl/cpu/torch-${TCH}-cp${
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
+
+ENTRYPOINT ["/app/rs"]
+CMD ["-h"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -20,3 +20,6 @@ RUN python3 -m pip install http://download.pytorch.org/whl/cu${CU}/torch-${TCH}-
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
+
+ENTRYPOINT ["/app/rs"]
+CMD ["-h"]


### PR DESCRIPTION
At the moment users have to run the docker container with `/app/rs` as a command. Because robosat always goes through the `rs` wrapper and the docker containers only package up robosat it's a better idea to make it the default entrypoint.

- Before
    `docker run --rm -it daniel-j-h/robosat:latest-cpu /app/rs extract ..`

- After
  `docker run --rm -it daniel-j-h/robosat:latest-cpu extract ..`

Without sub-command we show the help printout.

<details>

```
docker build -t daniel-j-h/robosat:latest-cpu -f docker/Dockerfile.cpu .

docker run --rm -it daniel-j-h/robosat:latest-cpu

usage: ./rs [-h]  ...

optional arguments:
  -h, --help  show this help message and exit
```

</details>

Supersedes https://github.com/mapbox/robosat/pull/140 - can be closed.

@jacquestardie please merge.
