### PR TITLE
Bakes pretrained model into docker image

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -15,7 +15,8 @@ ARG TCH=1.1.0
 ARG PY=36
 
 RUN python3 -m pip install http://download.pytorch.org/whl/cpu/torch-${TCH}-cp${PY}-cp${PY}m-linux_x86_64.whl     && \
-    python3 -m pip install -r deps/requirements-lock.txt
+    python3 -m pip install -r deps/requirements-lock.txt                                                          && \
+    python3 -c "from robosat.unet import UNet; UNet(2)"
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -16,7 +16,8 @@ ARG PY=36
 ARG CU=100
 
 RUN python3 -m pip install http://download.pytorch.org/whl/cu${CU}/torch-${TCH}-cp${PY}-cp${PY}m-linux_x86_64.whl && \
-    python3 -m pip install -r deps/requirements-lock.txt
+    python3 -m pip install -r deps/requirements-lock.txt                                                          && \
+    python3 -c "from robosat.unet import UNet; UNet(2)"
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
We use a pre-trained resnet in our encoder. The pre-trained weights are getting downloaded on-demand when we use the model for the first time. Usually this is fine when working without docker. With docker the container will get shut down after each command invokation which means we have to download the model weights every time we run a new `docker run .. train` command.

This changset instead pre-fetches the pre-trained weights and bakes them into the docker images at

```
~/.cache/torch/checkpoints/resnet50-19c8e357.pth
```

Then `docker run .. train` never has to download the weights on-demand, we are no longer dependent on external services, and everything works beautifully.

The downside is the docker image size will increase since the weights are ~100 MB. But because the nvidia docker image is a few GBs anyway I don't see a problem here.

@jacquestardie merge please! Tested this on my rig!