### PR TITLE
Splits docker build into cache-able layers for faster iteration

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,25 +1,25 @@
 FROM ubuntu:18.04
 
-# Python3 and native deps for bindings (pyosmium, rtree).
-#
-# libsm6 native dep. is required for opencv-contrib-python.
-# See: https://github.com/skvark/opencv-python/issues/90
-RUN apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y -o quiet=1 \
-    python3 python3-dev python3-tk python3-pip build-essential cmake libboost-python-dev libexpat1-dev zlib1g-dev libbz2-dev libspatialindex-dev libsm6
-
-WORKDIR /app
-ADD . /app
-
 ARG TCH=1.1.0
 ARG PY=36
 
-RUN python3 -m pip install http://download.pytorch.org/whl/cpu/torch-${TCH}-cp${PY}-cp${PY}m-linux_x86_64.whl     && \
-    python3 -m pip install -r deps/requirements-lock.txt                                                          && \
-    python3 -c "from robosat.unet import UNet; UNet(2)"
+WORKDIR /usr/src/app
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y -o quiet=1 \
+    python3 python3-dev python3-tk python3-pip libspatialindex-c4v5 libsm6
+
+RUN python3 -m pip install http://download.pytorch.org/whl/cpu/torch-${TCH}-cp${PY}-cp${PY}m-linux_x86_64.whl
+
+COPY deps/requirements-lock.txt deps/requirements-lock.txt
+RUN python3 -m pip install -r deps/requirements-lock.txt
+
+RUN python3 -c "from torchvision.models import resnet50; resnet50(True)"
+
+COPY . .
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-ENTRYPOINT ["/app/rs"]
+ENTRYPOINT ["/usr/src/app/rs"]
 CMD ["-h"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,26 +1,26 @@
 FROM nvidia/cuda:10.1-cudnn7-runtime
 
-# Python3 and native deps for bindings (pyosmium, rtree).
-#
-# libsm6 native dep. is required for opencv-contrib-python.
-# See: https://github.com/skvark/opencv-python/issues/90
-RUN apt-get update -qq && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y -o quiet=1 \
-    python3 python3-dev python3-tk python3-pip build-essential cmake libboost-python-dev libexpat1-dev zlib1g-dev libbz2-dev libspatialindex-dev libsm6
-
-WORKDIR /app
-ADD . /app
-
 ARG TCH=1.1.0
 ARG PY=36
 ARG CU=100
 
-RUN python3 -m pip install http://download.pytorch.org/whl/cu${CU}/torch-${TCH}-cp${PY}-cp${PY}m-linux_x86_64.whl && \
-    python3 -m pip install -r deps/requirements-lock.txt                                                          && \
-    python3 -c "from robosat.unet import UNet; UNet(2)"
+WORKDIR /usr/src/app
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qq -y -o quiet=1 \
+    python3 python3-dev python3-tk python3-pip libspatialindex-c4v5 libsm6
+
+RUN python3 -m pip install http://download.pytorch.org/whl/cu${CU}/torch-${TCH}-cp${PY}-cp${PY}m-linux_x86_64.whl
+
+COPY deps/requirements-lock.txt deps/requirements-lock.txt
+RUN python3 -m pip install -r deps/requirements-lock.txt
+
+RUN python3 -c "from torchvision.models import resnet50; resnet50(True)"
+
+COPY . .
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-ENTRYPOINT ["/app/rs"]
+ENTRYPOINT ["/usr/src/app/rs"]
 CMD ["-h"]


### PR DESCRIPTION
In https://github.com/mapbox/robosat/pull/151 we pre-fetched the model's weights into the docker image which makes iterating on training faster. In contrast this changeset is about improving on iteration speed for code development.

- Removes unused dependencies to make the image smaller and the docker build process faster; pyosmium switched from Boost.Python to pybind11 and is bundling zlib and expat in their wheel by now. The rtree package only required the C libspatialindex shared object.
- Creates a separate layer for the pytorch wheel. Changes a couple times a year and is quite big, should get cached.
- Creates a separate layer only for our dependencies. Again they should change only every now and then, installing the python depdency packages is slow, and we should cache this.
- Creates a separate layer for the pre-trained weights. By now we do not have the robosat source code in the docker layers yet so we use the underlying raw resnet model.
- Finally creates a layer with the robosat code which changes frequently when iterating on code and then building images to push onto my gpu rig.

Because we are now caching layers and carefully ordered them by how often they will change iterating on code is down from tens of minutes to a few seconds copying the new source code into the docker image.

:racehorse: :rocket:

cc @jacquestardie please merge; this works. (please merge with the rebase merge option to get a fast-forward merge keeping a linear git history)