### PR TITLE
Removes adam's l2 regularization until fixed in pytorch#4429

### DIFF
--- a/config/model-unet.toml
+++ b/config/model-unet.toml
@@ -27,8 +27,5 @@
   # Learning rate for the optimizer.
   lr         = 0.0001
 
-  # Weight decay l2 penalty for the optimizer
-  decay      = 0.0001
-
   # Loss function name (e.g 'Lovasz', 'mIoU' or 'CrossEntropy')
   loss = 'Lovasz'

--- a/robosat/tools/train.py
+++ b/robosat/tools/train.py
@@ -78,7 +78,7 @@ def main(args):
         if model["opt"]["loss"] in ("CrossEntropy", "mIoU", "Focal"):
             sys.exit("Error: The loss function used, need dataset weights values")
 
-    optimizer = Adam(net.parameters(), lr=model["opt"]["lr"], weight_decay=model["opt"]["decay"])
+    optimizer = Adam(net.parameters(), lr=model["opt"]["lr"])
 
     resume = 0
     if args.checkpoint:
@@ -118,7 +118,6 @@ def main(args):
     log.log("Batch Size:\t {}".format(model["common"]["batch_size"]))
     log.log("Image Size:\t {}".format(model["common"]["image_size"]))
     log.log("Learning Rate:\t {}".format(model["opt"]["lr"]))
-    log.log("Weight Decay:\t {}".format(model["opt"]["decay"]))
     log.log("Loss function:\t {}".format(model["opt"]["loss"]))
     if "weight" in locals():
         log.log("Weights :\t {}".format(dataset["weights"]["values"]))


### PR DESCRIPTION
pytorch's adam weight decay is l2 regularization and not what we want; until it is fixed and we get proper adamw we should just ignore it. See also https://www.fast.ai/2018/07/02/adam-weight-decay/