### PR TITLE
Faster JPEG decoding and vectorized image transformations (requires AVX2 support)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+dockerimage ?= mapbox/robosat
+dockerfile ?= docker/Dockerfile.cpu
+srcdir ?= $(shell pwd)
+datadir ?= $(shell pwd)
+
+install:
+	@docker build -t $(dockerimage) -f $(dockerfile) .
+
+i: install
+
+
+update:
+	@docker build -t $(dockerimage) -f $(dockerfile) . --pull --no-cache
+
+u: update
+
+
+run:
+	@docker run -it --rm --ipc="host" --network="host" -v $(srcdir)/robosat:/usr/src/app/robosat -v $(datadir):/data --entrypoint=/bin/bash $(dockerimage)
+
+r: run
+
+
+publish:
+	@docker image save $(dockerimage) \
+		| pv -N "Publish $(dockerimage) to $(sshopts)" -s $(shell docker image inspect $(dockerimage) --format "{{.Size}}") \
+		| ssh $(sshopts) "docker image load"
+
+p: publish
+
+
+.PHONY: install i run r update u publish p
+

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 COPY requirements.txt .
 
 RUN python3 -m venv /opt/venv && \
-    python3 -m pip install pip==19.1.1 pip-tools==3.7.0 && \
+    python3 -m pip install pip==19.2.3 pip-tools==4.1.0 && \
     python3 -m piptools sync
 
 RUN python3 -m pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl && \

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -2,11 +2,11 @@ FROM ubuntu:18.04
 
 WORKDIR /usr/src/app
 
-ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR="false"
+ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR="false" CFLAGS="-mavx2"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 \
-    gcc python3-dev libjpeg-turbo8-dev zlib1g-dev && \
+    wget gcc yasm cmake make python3-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -20,8 +20,22 @@ RUN python3 -m pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36
 
 RUN python3 -c "from torchvision.models import resnet50; resnet50(True)"
 
+RUN wget -q https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.3.tar.gz -O libjpeg-turbo.tar.gz && \
+    echo "a69598bf079463b34d45ca7268462a18b6507fdaa62bb1dfd212f02041499b5d libjpeg-turbo.tar.gz" | sha256sum -c && \
+    tar xf libjpeg-turbo.tar.gz && \
+    rm libjpeg-turbo.tar.gz && \
+    cd libjpeg-turbo* && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DREQUIRE_SIMD=On -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j $(nproc) && \
+    make install && \
+    ldconfig && \
+    cd ../../ && \
+    rm -rf libjpeg-turbo*
+
 RUN python3 -m pip uninstall -y pillow && \
-    CFLAGS="-mavx2" python3 -m pip install --no-binary :all: --compile pillow-simd==6.0.0.post0
+    python3 -m pip install --no-binary :all: --compile pillow-simd==6.0.0.post0
 
 COPY . .
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -5,7 +5,8 @@ WORKDIR /usr/src/app
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR="false"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 && \
+    python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 \
+    gcc python3-dev libjpeg-turbo8-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -18,6 +19,9 @@ RUN python3 -m pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36
     python3 -m pip install https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
 
 RUN python3 -c "from torchvision.models import resnet50; resnet50(True)"
+
+RUN python3 -m pip uninstall -y pillow && \
+    CFLAGS="-mavx2" python3 -m pip install --no-binary :all: --compile pillow-simd==6.0.0.post0
 
 COPY . .
 

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -5,7 +5,8 @@ WORKDIR /usr/src/app
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR="false"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 && \
+    python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 \
+    gcc python3-dev libjpeg-turbo8-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -18,6 +19,9 @@ RUN python3 -m pip install https://download.pytorch.org/whl/cu100/torch-1.1.0-cp
     python3 -m pip install https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
 
 RUN python3 -c "from torchvision.models import resnet50; resnet50(True)"
+
+RUN python3 -m pip uninstall -y pillow && \
+    CFLAGS="-mavx2" python3 -m pip install --no-binary :all: --compile pillow-simd==6.0.0.post0
 
 COPY . .
 

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 COPY requirements.txt .
 
 RUN python3 -m venv /opt/venv && \
-    python3 -m pip install pip==19.1.1 pip-tools==3.7.0 && \
+    python3 -m pip install pip==19.2.3 pip-tools==4.1.0 && \
     python3 -m piptools sync
 
 RUN python3 -m pip install https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl && \

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -2,11 +2,11 @@ FROM nvidia/cuda:10.1-cudnn7-runtime
 
 WORKDIR /usr/src/app
 
-ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR="false"
+ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR="false" CFLAGS="-mavx2"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 \
-    gcc python3-dev libjpeg-turbo8-dev zlib1g-dev && \
+    wget gcc yasm cmake make python3-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -20,8 +20,22 @@ RUN python3 -m pip install https://download.pytorch.org/whl/cu100/torch-1.1.0-cp
 
 RUN python3 -c "from torchvision.models import resnet50; resnet50(True)"
 
+RUN wget -q https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.3.tar.gz -O libjpeg-turbo.tar.gz && \
+    echo "a69598bf079463b34d45ca7268462a18b6507fdaa62bb1dfd212f02041499b5d libjpeg-turbo.tar.gz" | sha256sum -c && \
+    tar xf libjpeg-turbo.tar.gz && \
+    rm libjpeg-turbo.tar.gz && \
+    cd libjpeg-turbo* && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DREQUIRE_SIMD=On -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    make -j $(nproc) && \
+    make install && \
+    ldconfig && \
+    cd ../../ && \
+    rm -rf libjpeg-turbo*
+
 RUN python3 -m pip uninstall -y pillow && \
-    CFLAGS="-mavx2" python3 -m pip install --no-binary :all: --compile pillow-simd==6.0.0.post0
+    python3 -m pip install --no-binary :all: --compile pillow-simd==6.0.0.post0
 
 COPY . .
 


### PR DESCRIPTION
This changeset compiles Pillow-SIMD with AVX2 support for vectorized image operations (e.g. resize) and compiles against libjpeg-turbo for faster JPEG decoding.

The speedup is quite significant: the dataloaders can load, decode, and pre-process now like running a knife through butter. This takes considerable load off the CPU(s) and it's easier now to keep (potentially multiple) GPUs busy.

Note: downside is we require a machine with AVX2 support now. For GPU boxes this should be a given, and the 2015 laptop I'm writing this on comes with AVX2, too, so I'm happy to make it a default requirement.

Adding a convenient makefile in a second commit to make interaction with docker more pleasant.