### PR TITLE
Compiles Pillow-SIMD with libwebp support, closes #193

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -6,7 +6,7 @@ ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR=
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 \
-    wget gcc yasm cmake make python3-dev zlib1g-dev && \
+    wget gcc yasm cmake make python3-dev zlib1g-dev libwebp-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -6,7 +6,7 @@ ENV LANG="C.UTF-8" LC_ALL="C.UTF-8" PATH="/opt/venv/bin:$PATH" PIP_NO_CACHE_DIR=
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv libspatialindex-c4v5 libglib2.0-0 \
-    wget gcc yasm cmake make python3-dev zlib1g-dev && \
+    wget gcc yasm cmake make python3-dev zlib1g-dev libwebp-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .


### PR DESCRIPTION
Resolves #193. We compile Pillow-SIMD from source; if libwebp is not present we do not compile support for webp. This changeset fixes this mistake.

Pillow-SIMD compilation feature check: https://github.com/python-pillow/Pillow/blob/9b927155e693e0a337114422af46677991a010b0/setup.py#L659-L668

cc @oneOfThePeople